### PR TITLE
Change Image from net 5 to 6

### DIFF
--- a/src/EcommerceDDD.WebApi/Dockerfile
+++ b/src/EcommerceDDD.WebApi/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 5000
 EXPOSE 5001
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["src/EcommerceDDD.WebApi/EcommerceDDD.WebApi.csproj", "src/EcommerceDDD.WebApi/"]
 COPY ["src/EcommerceDDD.Infrastructure.IoC/EcommerceDDD.Infrastructure.IoC.csproj", "src/EcommerceDDD.Infrastructure.IoC/"]


### PR DESCRIPTION
It was not possible to find any compatible framework version

The framework 'Microsoft.NETCore.App', version '6.0.0' was not found.
  - The following frameworks were found:
      5.0.13 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]