### PR TITLE
Updated 'depends_on' for kafka_topics_ui

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,7 +223,7 @@ services:
     networks:
       - ecommercedddnet
     depends_on:
-      - kafka_rest
+      - kafka
 
 networks:
   ecommercedddnet:


### PR DESCRIPTION
Running `docker-compose up` gives the following error:

service "kafka_topics_ui" depends on undefined service kafka_rest: invalid compose project

Modifying 'depends_on' value from `kafka_rest` to `kafka` allows `docker-compose up` to run successfully.