### PR TITLE
Fix/identity server db migrate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,7 +223,7 @@ services:
     networks:
       - ecommercedddnet
     depends_on:
-      - kafka_rest
+      - kafka
 
 networks:
   ecommercedddnet:

--- a/src/Crosscutting/EcommerceDDD.IdentityServer/Configurations/IdentityConfiguration.cs
+++ b/src/Crosscutting/EcommerceDDD.IdentityServer/Configurations/IdentityConfiguration.cs
@@ -21,16 +21,6 @@ public class IdentityConfiguration
         {
             new ApiScope(api_scope, "EcommerceDDD API")
         };
-
-    public static IEnumerable<ApiResource> ApiResources =>
-        new ApiResource[]
-        {
-            new ApiResource(api_scope, "MyActions API")
-            {
-                Scopes = { api_scope }
-            }
-        };
-    
     
     public static IEnumerable<Client> Clients =>
         new Client[]

--- a/src/Crosscutting/EcommerceDDD.IdentityServer/Database/MigrationManager.cs
+++ b/src/Crosscutting/EcommerceDDD.IdentityServer/Database/MigrationManager.cs
@@ -1,0 +1,54 @@
+﻿using EcommerceDDD.IdentityServer.Configurations;
+using IdentityServer4.EntityFramework.DbContexts;
+using IdentityServer4.EntityFramework.Mappers;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcommerceDDD.IdentityServer.Database;
+
+public static class MigrationManager
+{
+    public static IHost MigrateDatabase(this IHost host)
+    {
+        using (var scope = host.Services.CreateScope())
+        {
+            scope.ServiceProvider
+                .GetRequiredService<PersistedGrantDbContext>().Database.Migrate();
+
+            using (var context = scope.ServiceProvider.GetRequiredService<ConfigurationDbContext>())
+            {
+                try
+                {
+                    context.Database.Migrate();
+
+                    if (!context.Clients.Any())
+                    {
+                        foreach (var client in IdentityConfiguration.Clients)
+                            context.Clients.Add(client.ToEntity());
+                    }
+
+                    if (!context.IdentityResources.Any())
+                    {
+                        foreach (var resource in IdentityConfiguration.IdentityResources)
+                            context.IdentityResources.Add(resource.ToEntity());
+                    }
+
+                    if (!context.ApiScopes.Any())
+                    {
+                        foreach (var apiScope in IdentityConfiguration.ApiScopes)
+                            context.ApiScopes.Add(apiScope.ToEntity());
+                    }
+
+                    context.SaveChanges();
+                }
+                catch (Exception ex)
+                {
+                    //Log errors or do anything you think it's needed
+                    throw;
+                }
+            }
+        }
+        return host;
+    }
+}
+
+//https://code-maze.com/migrate-identityserver4-configuration-to-database/


### PR DESCRIPTION
- Removed usage of IdentityServer4.AddInMemory methods 
- Added a "seeder" migration manager class extending **IHost**, so the migration worked fine when calling app.MigrateDatabase().Run(); from EcommerceDDD.IdentityServer/Program.cs 
