### PR TITLE
chore: adopt Central Package Management and update NuGet packages

### DIFF
--- a/.github/workflows/ecommerceddd-build.yml
+++ b/.github/workflows/ecommerceddd-build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,82 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Label="Entity Framework Core">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Authentication and Identity">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2" />
+    <PackageVersion Include="Duende.IdentityServer" Version="7.4.5" />
+    <PackageVersion Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.5" />
+    <PackageVersion Include="Duende.IdentityServer.EntityFramework" Version="7.4.5" />
+  </ItemGroup>
+
+  <ItemGroup Label="API Documentation">
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="API Versioning">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="API Gateway">
+    <PackageVersion Include="Ocelot" Version="24.1.0" />
+    <PackageVersion Include="Koalesce.OpenAPI" Version="1.0.0-alpha.12" />
+  </ItemGroup>
+
+  <ItemGroup Label="Event Sourcing and Messaging">
+    <PackageVersion Include="Marten" Version="8.19.0" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.13.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Resilience and DI">
+    <PackageVersion Include="Polly" Version="8.6.5" />
+    <PackageVersion Include="Scrutor" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Serialization">
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Label="Code Analysis">
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+	<PackageVersion Include="xunit" Version="2.9.3" />
+	<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+	<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	<PackageVersion Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Label="Tooling">
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Kiota (HTTP Client Generation)">
+	<PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.21.2" />
+	<PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.2" />
+	<PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.21.2" />
+	<PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.21.2" />
+	<PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.2" />
+	<PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.21.2" />
+  </ItemGroup>
+
+  <ItemGroup Label="HTTP and Resilience">
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.2" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,186 +1,190 @@
+# 🛒 EcommerceDDD
+
+An experimental full-stack application showcasing cutting-edge technologies and architectural patterns for building scalable e-commerce systems.
+
+⭐ **If you find this project useful, please consider giving it a star!** It helps others discover the project.
+
+![GitHub Stars](https://img.shields.io/github/stars/falberthen/ecommerceddd?style=social&logo=github)
+
+![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet) ![Angular](https://img.shields.io/badge/Angular-19-DD0031?logo=angular) ![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker)
 ![Build](https://github.com/falberthen/ecommerceddd/actions/workflows/ecommerceddd-build.yml/badge.svg)
 [![License](https://img.shields.io/github/license/falberthen/ecommerceddd.svg)](LICENSE)
-
-## Welcome to Ecommerce DDD
-This project is an experimental full-stack application I use to combine several cutting-edge technologies and architectural patterns. Thanks for getting here! please <b>give a ⭐</b> if you liked the project. It motivates me to keep improving it.
-<br><br>
-
-<a href="images/ecommerceddd-1.gif" target="_blank">
-<img src="images/ecommerceddd-1.gif" width="600px"/>
-</a>
-
-<a href="images/ecommerceddd-2.gif" target="_blank">
-<img src="images/ecommerceddd-2.gif" width="600px"/>
-</a>
-
-<a href="images/ecommerceddd-3.gif" target="_blank">
-<img src="images/ecommerceddd-3.gif" width="600px"/>
-</a>
-
----
-
-## Architecture
-
-### High-Level System Architecture
-<a href="images/EcommerceDDD-hl-architecture.png" target="_blank">
-<img src="images/EcommerceDDD-hl-architecture.png"/>
-</a>
-
-
-### Detailed Architecture
-<a href="images/EcommerceDDD-detailed-architecture.png" target="_blank">
-<img src="images/EcommerceDDD-detailed-architecture.png"/>
-</a>
-
-
-```
-├── Core
-├── Core.Infrastructure
-│
-├── Crosscutting
-│   ├── ServiceClients
-│   ├── ApiGateway
-│   ├── SignalR
-│   └── IdentityServer
-│
-├── Services
-│   ├── CustomerManagement
-│   ├── InventoryManagement
-│   ├── OrderProcessing
-│   ├── PaymentProcessing
-│   ├── ProductCatalog
-|   |   └─ EcommerceDDD.ProductCatalog
-│   │      ├── API
-│   │      ├── Application
-│   │      ├── Domain
-│   │      └── Infrastructure
-│   ├── QuoteManagement
-│   └── ShipmentProcessing
-│
-├── SPA
-└── docker-compose
-```
-
-- **Core** <br/>
-It defines the building blocks and abstractions used on all underlying projects. Its nature is very abstract, with no implementations.
-
-- **Core.Infrastructure** <br/>
-It holds some abstractions and implementation for infrastructure to be used by all microservices and underlying dependencies.
-
-- **Crosscutting** <br/>
-It contains project implementations that cross-cut all microservices, such as `IdentityServer`, `API gateway`, and `ServiceClients`. The `ServiceClients` project provides typed Kiota-generated HTTP clients for direct service-to-service communication.
-
-- **Services** <br/>
-The microservices composing the backend are built to be as simple as possible, structured as a vertically sliced structure with  `API`, `Application`, `Domain,` and `Infrastructure.`
-
-    ```
-      ├── EcommerceDDD.ProductCatalog
-      │   ├── API
-      │   ├── Application
-      │   ├── Domain
-      │   └── Infrastructure
-    ```
-
-  - **API** <br/>
-  RESTful API for enabling communication between client and server.
-
-  - **Application** <br/> 
-  It orchestrates the interactions between the external world and the domain to perform application tasks through use cases by `handling commands and queries`. 
-
-  - **Domain** <br/>
-  A structured implementation of the domain through aggregates, commands, value objects, domain services, repository definitions, and domain events.
-
-  - **Infrastructure** <br/>
-  It is a supporting library for upper layers, handling infrastructural matters such as data persistence with *implementing repositories*, database mapping, and external integrations.
-
-  - **SPA (Single Page Application)** <br/>
-  A lightweight Angular-based `SPA` providing a functional and user-friendly UI.
-
----
-
-## Service Communication
-
-### External Communication (SPA → Backend)
-The Angular SPA communicates with microservices through the **API Gateway**. The gateway uses [Koalesce.OpenAPI](https://github.com/falberthen/Koalesce) to aggregate all service OpenAPI specifications into a unified spec. **Kiota** then generates typed TypeScript clients from this unified specification for frontend consumption.
-
-### Internal Communication (Service-to-Service)
-Microservices communicate directly with each other using **Kiota-generated typed HTTP clients**, bypassing the API Gateway for internal operations. Each service has its own dedicated client.
-
----
-
-## Technologies used
-<ul>
-  <li>
-    <a href='https://get.asp.net' target="_blank">ASP.NET Core API</a> and <a href='https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12' target="_blank">C# 12</a>
-    for cross-platform backend with:
-    <ul>
-      <li>.NET 10</li>
-      <li><b>Koalesce.OpenAPI 1.0.0-alpha.10</b></li>
-      <li>Ocelot 24.1.0</li>
-      <li>Marten 8.17.0</li>
-      <li>Confluent Kafka 2.13.0</li>
-      <li>Entity Framework Core 10.0.1</li>
-      <li>Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0</li>
-      <li>ASP.NET Core Authentication JwtBearer 10.0.1</li>
-      <li>Duende IdentityServer 7.4.4</li>
-      <li>Polly 8.6.5</li>
-      <li>XUnit 2.9.3</li>
-      <li>NSubstitute 5.3.0</li>
-      <li>SwaggerGen/SwaggerUI 8.1.4</li>
-      <li>Microsoft.Kiota.* 1.21.1</li>
-    </ul>
-  </li>
-  <li>
-    <a href='https://angular.io/' target="_blank">Angular v19.2.7</a> and <a href='http://www.typescriptlang.org/' target="_blank">TypeScript 5.5.4</a> for the frontend with:
-    <ul>
-      <li>Jest 29.7.0</li>
-      <li>NgBootstrap 18.0.0/ Bootstrap 5.3.5</li>
-      <li>Font Awesome 6.7.2</li>
-      <li>Toastr 19.0.0</li>
-    </ul>
-  </li>
-</ul>
-
----
-
-## What do you need to run it 
-
-#### Running the microservices using Docker
-
-The project was designed to be easily run within docker containers, hence all you need is 1 command line to up everything. Make sure you have `Docker` installed and have fun!
-
-
-- Download Docker: <a href="https://docs.docker.com/docker-for-windows/wsl/" target="_blank">Docker Desktop with support for WLS 2</a>
-    
 <br/>
 
-Using a terminal, run:
+<p align="center">
+  <img src="images/ecommerceddd-1.gif" width="600" alt="Demo 1"/>
+</p>
 
-```console
- $ docker-compose up
-``` 
+<p align="center">
+  <img src="images/ecommerceddd-2.gif" width="600" alt="Demo 2"/>
+</p>
 
-You can also set the `docker-compose.dcproj` as a Startup project on Visual Studio if you want to run it while debugging.
+<p align="center">
+  <img src="images/ecommerceddd-3.gif" width="600" alt="Demo 3"/>
+</p>
 
-#### Regenerating Kiota Clients
+---
 
-After the containers are running, you can regenerate all Kiota HTTP clients (both backend and frontend) by executing:
+## 🏗️ Architecture
 
-```console
- $ docker-compose --profile tools run regenerate-clients
+### High-Level Overview
+
+<p align="center">
+  <img src="images/EcommerceDDD-hl-architecture.png" alt="High-Level Architecture"/>
+</p>
+
+### Detailed Architecture
+
+<p align="center">
+  <img src="images/EcommerceDDD-detailed-architecture.png" alt="Detailed Architecture"/>
+</p>
+
+---
+
+## 📁 Project Structure
+
+```
+├── Core                    # Building blocks and abstractions
+├── Core.Infrastructure     # Shared infrastructure implementations
+│
+├── Crosscutting
+│   ├── ServiceClients      # Kiota-generated HTTP clients
+│   ├── ApiGateway          # Ocelot API Gateway
+│   ├── SignalR             # Real-time communication
+│   └── IdentityServer      # Authentication & authorization
+│
+├── Services
+│   ├── CustomerManagement
+│   ├── InventoryManagement
+│   ├── OrderProcessing
+│   ├── PaymentProcessing
+│   ├── ProductCatalog
+│   ├── QuoteManagement
+│   └── ShipmentProcessing
+│
+├── SPA                     # Angular frontend
+└── docker-compose          # Container orchestration
+```
+
+
+| Layer | |
+|-------|-------------|
+| **Core** | Defines building blocks and abstractions used across all projects. Highly abstract with no implementations. |
+| **Core.Infrastructure** | Shared infrastructure abstractions and implementations for all microservices. |
+| **Crosscutting** | Projects that cross-cut all microservices: `IdentityServer`, `API Gateway`, and `ServiceClients` with Kiota-generated HTTP clients. |
+| **Services** | Backend microservices built with a vertically sliced structure. |
+| **SPA** | Lightweight Angular-based Single Page Application. |
+
+<br/>
+
+### Microservice Structure
+
+Each microservice follows a clean vertical slice architecture.
+
+```
+├── EcommerceDDD.ProductCatalog
+│   ├── API              # RESTful endpoints
+│   ├── Application      # Use cases, commands & queries
+│   ├── Domain           # Aggregates, entities, domain events
+│   └── Infrastructure   # Data persistence & external integrations
+```
+
+---
+
+## 🔗 Service Communication
+
+#### External Communication (SPA → Backend)
+
+- [Koalesce.OpenAPI](https://github.com/falberthen/Koalesce) aggregates all OpenAPI definitions exposed in the **API Gateway**.
+- **Kiota** generates typed TypeScript clients from this unified spec.
+- The Angular SPA communicates through the **API Gateway** using the clients.
+
+#### Internal Communication (Service-to-Service)
+
+Microservices communicate directly using **Kiota-generated typed HTTP clients**.
+
+---
+
+## 🛠️ Tech Stack
+
+### Backend
+
+| Technology | Version |
+|------------|---------|
+| .NET | 10 |
+| C# | 12 |
+| Koalesce.OpenAPI | 1.0.0-alpha.12 |
+| Ocelot | 24.1.0 |
+| Marten | 8.19.0 |
+| Confluent Kafka | 2.13.0 |
+| Entity Framework Core | 10.0.2 |
+| Npgsql (PostgreSQL) | 10.0.0 |
+| Duende IdentityServer | 7.4.5 |
+| Polly | 8.6.5 |
+| Microsoft Kiota | 1.21.2 |
+| xUnit | 2.9.3 |
+| NSubstitute | 5.3.0 |
+
+### Frontend
+
+| Technology | Version |
+|------------|---------|
+| Angular | 19.2.7 |
+| TypeScript | 5.5.4 |
+| Jest | 29.7.0 |
+| NgBootstrap | 18.0.0 |
+| Bootstrap | 5.3.5 |
+| Font Awesome | 6.7.2 |
+| Toastr | 19.0.0 |
+
+---
+
+## 🔌 Getting Started
+
+### Running with Docker
+
+```bash
+# Start all services
+docker-compose up
+```
+
+> 💡 **Tip:** You can also set `docker-compose.dcproj` as the startup project in Visual Studio for debugging.
+
+<br/>
+
+
+### Running the Angular SPA
+
+```bash
+cd EcommerceDDD.Spa
+npm install
+ng serve
+```
+
+Open your browser at `http://localhost:4200`
+
+<br/>
+
+### Regenerating Kiota Clients
+
+If you want to regenerate all typed HTTP clients, after containers are running:
+
+```bash
+docker-compose --profile tools run regenerate-clients
 ```
 
 This generates:
-- **Backend clients** (C#): Service-to-service typed clients in `ServiceClients/Kiota/`
-- **Frontend client** (TypeScript): Unified client for the SPA in `EcommerceDDD.Spa/src/app/clients/`
+- **Backend clients (C#):** `ServiceClients/Kiota/`
+- **Single Frontend client (TypeScript):** `EcommerceDDD.Spa/src/app/clients/`
 
 ---
 
-### Running the Angular SPA
-    
-Using a terminal, navigate to `EcommerceDDD.Spa` and run for the following commands the node packages and serving the SPA on `http://localhost:4200` respectively:
+## 📄 License
 
-```console
- $ npm install
- $ ng serve
-```
+This project is licensed under the terms of the [LICENSE](LICENSE) file.
+
+---
+
+<p align="center">
+  Made with ❤️ by <a href="https://github.com/falberthen">Felipe Henrique</a>
+</p>

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -9,6 +9,7 @@
     <DockerServiceName>ecommerceddd.orders</DockerServiceName>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="Directory.Packages.props" />
     <None Include="docker-compose.yml" />
   </ItemGroup>
 </Project>

--- a/src/Core/EcommerceDDD.Core.Infrastructure.Tests/EcommerceDDD.Core.Infrastructure.Tests.csproj
+++ b/src/Core/EcommerceDDD.Core.Infrastructure.Tests/EcommerceDDD.Core.Infrastructure.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj
@@ -8,26 +8,22 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Confluent.Kafka" Version="2.13.0" />
-		<PackageReference Include="Duende.IdentityServer" Version="7.4.4" />
-		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.4" />
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.4.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0" />
-		<PackageReference Include="Polly" Version="8.6.5" />
-		<PackageReference Include="Scrutor" Version="7.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+		<PackageReference Include="Confluent.Kafka" />
+		<PackageReference Include="Duende.IdentityServer" />
+		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="Scrutor" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
@@ -46,4 +46,5 @@ global using System.Net.Mime;
 global using System.Reflection;
 global using System.Security.Claims;
 global using System.Text;
-global using Microsoft.OpenApi.Models;
+global using Microsoft.OpenApi;
+global using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Core/EcommerceDDD.Core.Infrastructure/WebApi/SecurityRequirementsOperationFilter.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/WebApi/SecurityRequirementsOperationFilter.cs
@@ -1,0 +1,33 @@
+﻿namespace EcommerceDDD.Core.Infrastructure.WebApi;
+
+/// <summary>
+/// Operation filter that adds Bearer security requirement only to endpoints requiring authorization
+/// </summary>
+public class SecurityRequirementsOperationFilter : IOperationFilter
+{
+	public void Apply(OpenApiOperation operation, OperationFilterContext context)
+	{
+		// Check if endpoint has AllowAnonymous attribute
+		var hasAllowAnonymous = context.ApiDescription.ActionDescriptor.EndpointMetadata
+			.Any(em => em is AllowAnonymousAttribute);
+
+		// Check if endpoint requires authorization
+		var hasAuthorize = context.ApiDescription.ActionDescriptor.EndpointMetadata
+			.Any(em => em is AuthorizeAttribute);
+
+		// Only add security if endpoint requires authorization and doesn't allow anonymous
+		if (hasAuthorize && !hasAllowAnonymous)
+		{
+			// Use OpenApiSecuritySchemeReference for Microsoft.OpenApi v2.x
+			var securitySchemeReference = new OpenApiSecuritySchemeReference("Bearer", context.Document);
+
+			operation.Security = new List<OpenApiSecurityRequirement>
+			{
+				new OpenApiSecurityRequirement
+				{
+					[securitySchemeReference] = new List<string>()
+				}
+			};
+		}
+	}
+}

--- a/src/Core/EcommerceDDD.Core.Tests/EcommerceDDD.Core.Tests.csproj
+++ b/src/Core/EcommerceDDD.Core.Tests/EcommerceDDD.Core.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj
+++ b/src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>	
-	<PackageReference Include="Marten" Version="8.17.0" />
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-	<PackageReference Include="NSubstitute" Version="5.3.0" />
-	<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
-	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
+	<PackageReference Include="Marten" />
+	<PackageReference Include="Newtonsoft.Json" />
+	<PackageReference Include="NSubstitute" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Common" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Dockerfile
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Crosscutting/EcommerceDDD.ApiGateway/EcommerceDDD.ApiGateway.csproj", "src/Crosscutting/EcommerceDDD.ApiGateway/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/EcommerceDDD.ApiGateway.csproj
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/EcommerceDDD.ApiGateway.csproj
@@ -13,9 +13,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Koalesce.OpenAPI" Version="1.0.0-alpha.10" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-		<PackageReference Include="Ocelot" Version="24.1.0" />
+		<PackageReference Include="Koalesce.OpenAPI" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+		<PackageReference Include="Ocelot" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.customerManagement.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.customerManagement.json
@@ -1,7 +1,7 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/CustomerManagement/api/v{version}/customers/{everything}",
+      "UpstreamPathTemplate": "/customerManagement/api/v{version}/customers/{everything}",
       "DownstreamPathTemplate": "/api/v{version}/customers/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.inventoryManagement.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.inventoryManagement.json
@@ -1,7 +1,7 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/InventoryManagement/api/v{version}/inventory/{everything}",
+      "UpstreamPathTemplate": "/inventoryManagement/api/v{version}/inventory/{everything}",
       "DownstreamPathTemplate": "/api/v{version}/inventory/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.json
@@ -83,7 +83,7 @@
         "PUT",
         "DELETE"
       ],
-      "UpstreamPathTemplate": "/CustomerManagement/api/v{version}/customers/{everything}",
+      "UpstreamPathTemplate": "/customerManagement/api/v{version}/customers/{everything}",
       "AuthenticationOptions": null,
       "CacheOptions": null,
       "DownstreamHttpVersionPolicy": null,
@@ -133,7 +133,7 @@
         "POST",
         "PUT"
       ],
-      "UpstreamPathTemplate": "/InventoryManagement/api/v{version}/inventory/{everything}",
+      "UpstreamPathTemplate": "/inventoryManagement/api/v{version}/inventory/{everything}",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,
@@ -191,7 +191,7 @@
         "DELETE",
         "POST"
       ],
-      "UpstreamPathTemplate": "/OrderProcessing/api/v{version}/orders/{everything}",
+      "UpstreamPathTemplate": "/orderProcessing/api/v{version}/orders/{everything}",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,
@@ -247,7 +247,7 @@
         "POST",
         "DELETE"
       ],
-      "UpstreamPathTemplate": "/PaymentProcessing/api/v{version}/payments/{everything}",
+      "UpstreamPathTemplate": "/paymentProcessing/api/v{version}/payments/{everything}",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,
@@ -303,7 +303,7 @@
         "POST",
         "GET"
       ],
-      "UpstreamPathTemplate": "/ProductCatalog/api/v{version}/products",
+      "UpstreamPathTemplate": "/productCatalog/api/v{version}/products",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,
@@ -418,7 +418,7 @@
         "PUT",
         "DELETE"
       ],
-      "UpstreamPathTemplate": "/QuoteManagement/api/v{version}/quotes/{everything}",
+      "UpstreamPathTemplate": "/quoteManagement/api/v{version}/quotes/{everything}",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,
@@ -473,7 +473,7 @@
       "UpstreamHttpMethod": [
         "POST"
       ],
-      "UpstreamPathTemplate": "/ShipmentProcessing/api/v{version}/shipments",
+      "UpstreamPathTemplate": "/shipmentProcessing/api/v{version}/shipments",
       "AuthenticationOptions": {
         "AllowedScopes": null,
         "AllowAnonymous": null,

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.orderProcessing.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.orderProcessing.json
@@ -1,7 +1,7 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/OrderProcessing/api/v{version}/orders/{everything}",
+      "UpstreamPathTemplate": "/orderProcessing/api/v{version}/orders/{everything}",
       "DownstreamPathTemplate": "/api/v{version}/orders/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.paymentProcessing.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.paymentProcessing.json
@@ -1,7 +1,7 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/PaymentProcessing/api/v{version}/payments/{everything}",
+      "UpstreamPathTemplate": "/paymentProcessing/api/v{version}/payments/{everything}",
       "DownstreamPathTemplate": "/api/v{version}/payments/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.productCatalog.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.productCatalog.json
@@ -1,27 +1,27 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/ShipmentProcessing/api/v{version}/shipments",
-      "DownstreamPathTemplate": "/api/v{version}/shipments",
+      "UpstreamPathTemplate": "/productCatalog/api/v{version}/products",
+      "DownstreamPathTemplate": "/api/v{version}/products",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "ecommerceddd-shipment-processing",
+          "Host": "ecommerceddd-product-catalog",
           "Port": 80
         }
       ],
-      "UpstreamHttpMethod": [ "POST" ],
+      "UpstreamHttpMethod": [ "POST", "GET" ],
       "AuthenticationOptions": {
         "AuthenticationProviderKey": "Bearer"
       }
     },
     {
-      "UpstreamPathTemplate": "/ShipmentProcessing/api/v{version}/shipments/{everything}",
-      "DownstreamPathTemplate": "/api/v{version}/shipments/{everything}",
+      "UpstreamPathTemplate": "/ProductCatalog/api/v{version}/products/{everything}",
+      "DownstreamPathTemplate": "/api/v{version}/products/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "ecommerceddd-shipment-processing",
+          "Host": "ecommerceddd-product-catalog",
           "Port": 80
         }
       ],

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.quoteManagement.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.quoteManagement.json
@@ -1,7 +1,7 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/QuoteManagement/api/v{version}/quotes/{everything}",
+      "UpstreamPathTemplate": "/quoteManagement/api/v{version}/quotes/{everything}",
       "DownstreamPathTemplate": "/api/v{version}/quotes/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.shipmentProcessing.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Ocelot/ocelot.shipmentProcessing.json
@@ -1,27 +1,27 @@
 {
   "Routes": [
     {
-      "UpstreamPathTemplate": "/ProductCatalog/api/v{version}/products",
-      "DownstreamPathTemplate": "/api/v{version}/products",
+      "UpstreamPathTemplate": "/shipmentProcessing/api/v{version}/shipments",
+      "DownstreamPathTemplate": "/api/v{version}/shipments",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "ecommerceddd-product-catalog",
+          "Host": "ecommerceddd-shipment-processing",
           "Port": 80
         }
       ],
-      "UpstreamHttpMethod": [ "POST", "GET" ],
+      "UpstreamHttpMethod": [ "POST" ],
       "AuthenticationOptions": {
         "AuthenticationProviderKey": "Bearer"
       }
     },
     {
-      "UpstreamPathTemplate": "/ProductCatalog/api/v{version}/products/{everything}",
-      "DownstreamPathTemplate": "/api/v{version}/products/{everything}",
+      "UpstreamPathTemplate": "/ShipmentProcessing/api/v{version}/shipments/{everything}",
+      "DownstreamPathTemplate": "/api/v{version}/shipments/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "ecommerceddd-product-catalog",
+          "Host": "ecommerceddd-shipment-processing",
           "Port": 80
         }
       ],

--- a/src/Crosscutting/EcommerceDDD.IdentityServer/Dockerfile
+++ b/src/Crosscutting/EcommerceDDD.IdentityServer/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Crosscutting/EcommerceDDD.IdentityServer/EcommerceDDD.IdentityServer.csproj", "src/Crosscutting/EcommerceDDD.IdentityServer/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Crosscutting/EcommerceDDD.IdentityServer/EcommerceDDD.IdentityServer.csproj
+++ b/src/Crosscutting/EcommerceDDD.IdentityServer/EcommerceDDD.IdentityServer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Crosscutting/EcommerceDDD.ServiceClients/EcommerceDDD.ServiceClients.csproj
+++ b/src/Crosscutting/EcommerceDDD.ServiceClients/EcommerceDDD.ServiceClients.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Crosscutting/EcommerceDDD.SignalR/Dockerfile
+++ b/src/Crosscutting/EcommerceDDD.SignalR/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Crosscutting/EcommerceDDD.SignalR/EcommerceDDD.SignalR.csproj", "src/Crosscutting/EcommerceDDD.SignalR/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Crosscutting/EcommerceDDD.SignalR/EcommerceDDD.SignalR.csproj
+++ b/src/Crosscutting/EcommerceDDD.SignalR/EcommerceDDD.SignalR.csproj
@@ -14,7 +14,7 @@
 	<ProjectReference Include="..\..\Core\EcommerceDDD.Core\EcommerceDDD.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
 </Project>

--- a/src/EcommerceDDD.Spa/src/app/modules/ecommerce/components/home/home.component.html
+++ b/src/EcommerceDDD.Spa/src/app/modules/ecommerce/components/home/home.component.html
@@ -2,36 +2,4 @@
   <div class="alert alert-info" role="alert">
     <h1 class="alert-heading text-center">Welcome to Ecommerce DDD!</h1>
   </div>
-  <p>This application was built using:</p>
-  <ul>
-    <li>
-      <a href='https://get.asp.net' target="_blank">ASP.NET Core API</a> and <a href='https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12' target="_blank">C# 12</a>
-      for cross-platform backend with:
-      <ul>
-        <li>.NET 10</li>
-        <li><b>Koalesce.OpenAPI 1.0.0-alpha.10</b></li>
-        <li>Ocelot 24.1.0</li>
-        <li>Marten 8.17.0</li>
-        <li>Confluent Kafka 2.13.0</li>
-        <li>Entity Framework Core 10.0.1</li>
-        <li>Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0</li>
-        <li>ASP.NET Core Authentication JwtBearer 10.0.1</li>
-        <li>Duende IdentityServer 7.4.4</li>
-        <li>Polly 8.6.5</li>
-        <li>XUnit 2.9.3</li>
-        <li>NSubstitute 5.3.0</li>
-        <li>SwaggerGen/SwaggerUI 8.1.4</li>
-        <li>Microsoft.Kiota.* 1.21.1</li>
-      </ul>
-    </li>
-    <li>
-      <a href='https://angular.io/' target="_blank">Angular v19.2.7</a> and <a href='http://www.typescriptlang.org/' target="_blank">TypeScript 5.5.4</a> for the frontend with:
-      <ul>
-        <li>Jest 29.7.0</li>
-        <li>NgBootstrap 18.0.0/ Bootstrap 5.3.5</li>
-        <li>Font Awesome 6.7.2</li>
-        <li>Toastr 19.0.0</li>
-      </ul>
-    </li>
-  </ul>
 </div>

--- a/src/Services/EcommerceDDD.CustomerManagement.Tests/EcommerceDDD.CustomerManagement.Tests.csproj
+++ b/src/Services/EcommerceDDD.CustomerManagement.Tests/EcommerceDDD.CustomerManagement.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
 	  <ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
     <ProjectReference Include="..\EcommerceDDD.CustomerManagement\EcommerceDDD.CustomerManagement.csproj" />

--- a/src/Services/EcommerceDDD.CustomerManagement/Dockerfile
+++ b/src/Services/EcommerceDDD.CustomerManagement/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.CustomerManagement/EcommerceDDD.CustomerManagement.csproj", "src/Services/EcommerceDDD.CustomerManagement/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.CustomerManagement/EcommerceDDD.CustomerManagement.csproj
+++ b/src/Services/EcommerceDDD.CustomerManagement/EcommerceDDD.CustomerManagement.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.InventoryManagement.Tests/EcommerceDDD.InventoryManagement.Tests.csproj
+++ b/src/Services/EcommerceDDD.InventoryManagement.Tests/EcommerceDDD.InventoryManagement.Tests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Services/EcommerceDDD.InventoryManagement/Dockerfile
+++ b/src/Services/EcommerceDDD.InventoryManagement/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.InventoryManagement/EcommerceDDD.InventoryManagement.csproj", "src/Services/EcommerceDDD.InventoryManagement/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.InventoryManagement/EcommerceDDD.InventoryManagement.csproj
+++ b/src/Services/EcommerceDDD.InventoryManagement/EcommerceDDD.InventoryManagement.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/EcommerceDDD.OrderProcessing.Tests.csproj
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/EcommerceDDD.OrderProcessing.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
 		<ProjectReference Include="..\EcommerceDDD.OrderProcessing\EcommerceDDD.OrderProcessing.csproj" />
 	</ItemGroup>

--- a/src/Services/EcommerceDDD.OrderProcessing/Dockerfile
+++ b/src/Services/EcommerceDDD.OrderProcessing/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.OrderProcessing/EcommerceDDD.OrderProcessing.csproj", "src/Services/EcommerceDDD.OrderProcessing/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.OrderProcessing/EcommerceDDD.OrderProcessing.csproj
+++ b/src/Services/EcommerceDDD.OrderProcessing/EcommerceDDD.OrderProcessing.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.PaymentProcessing.Tests/EcommerceDDD.PaymentProcessing.Tests.csproj
+++ b/src/Services/EcommerceDDD.PaymentProcessing.Tests/EcommerceDDD.PaymentProcessing.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
     <ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
     <ProjectReference Include="..\EcommerceDDD.PaymentProcessing\EcommerceDDD.PaymentProcessing.csproj" />
   </ItemGroup>

--- a/src/Services/EcommerceDDD.PaymentProcessing/Dockerfile
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.PaymentProcessing/EcommerceDDD.PaymentProcessing.csproj", "src/Services/EcommerceDDD.PaymentProcessing/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.PaymentProcessing/EcommerceDDD.PaymentProcessing.csproj
+++ b/src/Services/EcommerceDDD.PaymentProcessing/EcommerceDDD.PaymentProcessing.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.ProductCatalog.Tests/EcommerceDDD.ProductCatalog.Tests.csproj
+++ b/src/Services/EcommerceDDD.ProductCatalog.Tests/EcommerceDDD.ProductCatalog.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
 		<ProjectReference Include="..\EcommerceDDD.ProductCatalog\EcommerceDDD.ProductCatalog.csproj" />
 	</ItemGroup>

--- a/src/Services/EcommerceDDD.ProductCatalog/Dockerfile
+++ b/src/Services/EcommerceDDD.ProductCatalog/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.ProductCatalog/EcommerceDDD.ProductCatalog.csproj", "src/Services/EcommerceDDD.ProductCatalog/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.ProductCatalog/EcommerceDDD.ProductCatalog.csproj
+++ b/src/Services/EcommerceDDD.ProductCatalog/EcommerceDDD.ProductCatalog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.QuoteManagement.Tests/EcommerceDDD.QuoteManagement.Tests.csproj
+++ b/src/Services/EcommerceDDD.QuoteManagement.Tests/EcommerceDDD.QuoteManagement.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
     <ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
     <ProjectReference Include="..\EcommerceDDD.QuoteManagement\EcommerceDDD.QuoteManagement.csproj" />
   </ItemGroup>

--- a/src/Services/EcommerceDDD.QuoteManagement/Dockerfile
+++ b/src/Services/EcommerceDDD.QuoteManagement/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.QuoteManagement/EcommerceDDD.QuoteManagement.csproj", "src/Services/EcommerceDDD.QuoteManagement/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.QuoteManagement/EcommerceDDD.QuoteManagement.csproj
+++ b/src/Services/EcommerceDDD.QuoteManagement/EcommerceDDD.QuoteManagement.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/EcommerceDDD.ShipmentProcessing.Tests/EcommerceDDD.ShipmentProcessing.Tests.csproj
+++ b/src/Services/EcommerceDDD.ShipmentProcessing.Tests/EcommerceDDD.ShipmentProcessing.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
     <ProjectReference Include="..\..\Core\EcommerceDDD.Core.Infrastructure.Tests\EcommerceDDD.Core.Infrastructure.Tests.csproj" />
     <ProjectReference Include="..\..\Core\EcommerceDDD.Core\EcommerceDDD.Core.csproj" />
     <ProjectReference Include="..\EcommerceDDD.ShipmentProcessing\EcommerceDDD.ShipmentProcessing.csproj" />

--- a/src/Services/EcommerceDDD.ShipmentProcessing/Dockerfile
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "./"]
 COPY ["src/Services/EcommerceDDD.ShipmentProcessing/EcommerceDDD.ShipmentProcessing.csproj", "src/Services/EcommerceDDD.ShipmentProcessing/"]
 COPY ["src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj", "src/Core/EcommerceDDD.Core.Infrastructure/"]
 COPY ["src/Core/EcommerceDDD.Core/EcommerceDDD.Core.csproj", "src/Core/EcommerceDDD.Core/"]

--- a/src/Services/EcommerceDDD.ShipmentProcessing/EcommerceDDD.ShipmentProcessing.csproj
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/EcommerceDDD.ShipmentProcessing.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Changed

- Adopt Central Package Management (Directory.Packages.props).
- Update all NuGet packages to the latest versions.
- Update Ocelot route configurations.
- Refactor Swagger extensions for .NET 10 compatibility.
- Update build workflow (GitHub Actions).
- Improve README structure and content.