### PR TITLE
chore: updated Koalesce to new packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
 
   <ItemGroup Label="API Gateway">
     <PackageVersion Include="Ocelot" Version="24.1.0" />
-    <PackageVersion Include="Koalesce.OpenAPI" Version="1.0.0-alpha.12" />
+    <PackageVersion Include="Koalesce" Version="1.0.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup Label="Event Sourcing and Messaging">

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/EcommerceDDD.ApiGateway.csproj
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/EcommerceDDD.ApiGateway.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Koalesce.OpenAPI" />
+		<PackageReference Include="Koalesce" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
 		<PackageReference Include="Ocelot" />
 	</ItemGroup>

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/GlobalUsings.cs
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/GlobalUsings.cs
@@ -3,5 +3,5 @@ global using EcommerceDDD.Core.Infrastructure.WebApi;
 global using Microsoft.Extensions.Options;
 global using Ocelot.DependencyInjection;
 global using Ocelot.Middleware;
-global using Koalesce.Core.Extensions;
-global using Koalesce.OpenAPI.Extensions;
+global using Koalesce.Extensions;
+global using Koalesce.Options;

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/Program.cs
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/Program.cs
@@ -41,8 +41,7 @@ services.AddCors(o =>
 
 
 // Register Koalesce
-services.AddKoalesce(builder.Configuration)
-	.ForOpenAPI();
+services.AddKoalesce(builder.Configuration);
 
 // Build the app
 var app = builder.Build();
@@ -69,7 +68,7 @@ using (var scope = app.Services.CreateScope())
 	// Enable Swagger UI
 	app.UseSwaggerUI(c =>
 	{
-		c.SwaggerEndpoint(koalesceOptions.MergedDocumentPath, koalesceOptions.Title);
+		c.SwaggerEndpoint(koalesceOptions.MergedEndpoint, koalesceOptions.Title);
 	});
 }
 

--- a/src/Crosscutting/EcommerceDDD.ApiGateway/appsettings.json
+++ b/src/Crosscutting/EcommerceDDD.ApiGateway/appsettings.json
@@ -12,7 +12,7 @@
   "Koalesce": {
     "OpenApiVersion": "3.0.1",
     "Title": "Ecommerce DDD API Gateway",
-    "Sources": [      
+    "Sources": [
       {
         "Url": "http://ecommerceddd-identityserver/swagger/v2/swagger.json",
         "ExcludePaths": [
@@ -52,9 +52,8 @@
         "VirtualPrefix": "/orderProcessing"
       }
     ],
-    "MergedDocumentPath": "/swagger/v2/apigateway.yaml",
+    "MergedEndpoint": "/swagger/v2/apigateway.yaml",
     "ApiGatewayBaseUrl": "http://localhost:5000",
-    "SchemaConflictPattern": "{Prefix}{SchemaName}",
     "Cache": {
       "MinExpirationSeconds": 10,
       "SlidingExpirationSeconds": 10


### PR DESCRIPTION
### Changes

- Updated Koalesce.OpenAPI (now deprecated) to **Koalesce 1.0.0-beta.1**