### PR TITLE
fix(openTelemetry): add distributed tracing across Kafka boundaries

### DIFF
--- a/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ActivitySources.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ActivitySources.cs
@@ -1,0 +1,6 @@
+﻿namespace EcommerceDDD.Core.Infrastructure.OpenTelemetry;
+
+public static class ActivitySources
+{
+	public const string KafkaConsumer = "EcommerceDDD.Kafka.Consumer";
+}

--- a/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/OpenTelemetryExtension.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/OpenTelemetryExtension.cs
@@ -12,6 +12,7 @@ public static class OpenTelemetryExtension
                 tracing
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
+                    .AddSource(ActivitySources.KafkaConsumer)
                     .AddOtlpExporter();
             })
             .WithMetrics(metrics =>

--- a/src/Core/EcommerceDDD.Core.Infrastructure/WebApi/ControllerBaseProblemDetailsExtensions.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/WebApi/ControllerBaseProblemDetailsExtensions.cs
@@ -23,7 +23,8 @@ public static class ControllerBaseProblemDetailsExtensions
 
 		if (controller.HttpContext is not null)
 		{
-			problem.Extensions["traceId"] = controller.HttpContext.TraceIdentifier;
+			problem.Extensions["traceId"] = Activity.Current?.TraceId.ToString()
+				?? controller.HttpContext.TraceIdentifier;
 		}
 
 		if (extensions is not null)
@@ -64,7 +65,8 @@ public static class ControllerBaseProblemDetailsExtensions
 
 		if (controller.HttpContext is not null)
 		{
-			problem.Extensions["traceId"] = controller.HttpContext.TraceIdentifier;
+			problem.Extensions["traceId"] = Activity.Current?.TraceId.ToString()
+				?? controller.HttpContext.TraceIdentifier;
 		}
 
 		if (extensions is not null)
@@ -77,7 +79,7 @@ public static class ControllerBaseProblemDetailsExtensions
 
 		return controller.StatusCode(statusCode, problem);
 	}
-	
+
 	// Convenience helpers for common status codes
 	public static IActionResult BadRequestProblem(
 		this ControllerBase controller,

--- a/src/Core/EcommerceDDD.Core/EventBus/IntegrationEvent.cs
+++ b/src/Core/EcommerceDDD.Core/EventBus/IntegrationEvent.cs
@@ -5,10 +5,11 @@ public class IntegrationEvent : IIntegrationEvent
     public Guid Id { get; } = Guid.NewGuid();
     public string EventName { get; } // Event name identifier
     public string JSON_Payload { get; } // Serialized data
+    public string? TraceContext { get; } // W3C traceparent for distributed tracing
 
     public static IntegrationEvent FromNotification(INotification domainEvent)
     {
-		if(domainEvent == null) 
+		if(domainEvent == null)
 			throw new ArgumentNullException(nameof(domainEvent));
 
         return new IntegrationEvent(domainEvent);
@@ -20,5 +21,6 @@ public class IntegrationEvent : IIntegrationEvent
     {
         EventName = @event.GetType().Name;
         JSON_Payload = JsonConvert.SerializeObject(@event);
-    }    
+        TraceContext = Activity.Current?.Id;
+    }
 }

--- a/src/Core/EcommerceDDD.Core/GlobalUsings.cs
+++ b/src/Core/EcommerceDDD.Core/GlobalUsings.cs
@@ -12,3 +12,4 @@ global using System.Collections.Generic;
 global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
+global using System.Diagnostics;


### PR DESCRIPTION
### Fixed
- Replace HttpContext.TraceIdentifier with Activity.Current.TraceId in all ProblemDetails responses, so error traceIds match what is visible in the Aspire Dashboard.
- Add W3C TraceContext (traceparent) to IntegrationEvent outbox payload, captured at write time.
- In KafkaConsumer, restore the producer ActivityContext from the outbox payload and register it as an ActivityLink per the OTel Messaging Specification, linking consumer traces causally to the originating request without collapsing the async boundary into a single trace hierarchy.