### PR TITLE
fix(otel): improve distributed tracing coverage and semantic conventions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,6 +49,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup Label="Code Analysis">
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to EcommerceDDD
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch from `master`
+3. Make your changes
+4. Submit a Pull Request
+
+---
+
+## Solution Structure
+
+The repository contains multiple solution files for different purposes:
+
+### Main Solution (`EcommerceDDD.sln`)
+
+Use this sln for library development and testing.
+
+---
+
+## Pull Request Guidelines
+
+- **One concern per PR** - Keep PRs focused and atomic
+- **Write tests** - New features and bug fixes should include tests
+- **Follow code style** - Match existing patterns in the codebase
+- **Update documentation** - If your change affects public APIs
+
+---
+
+## Branch Naming
+
+- `feat/description` - New features
+- `fix/description` - Bug fixes
+- `refactor/description` - Code restructuring without behavior changes
+- `chore/description` - Maintenance tasks (dependencies, CI, etc.)
+- `docs/description` - Documentation only
+
+---
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+feat: add support for OpenTelemetry
+fix: fix latency issues while processing
+refactor: reorganize test project structure
+docs: update README with new package updates
+```
+
+---
+
+## Code Review
+
+All PRs require review before merging. Please be patient and responsive to feedback.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,10 @@
 
 An experimental full-stack application showcasing cutting-edge technologies and architectural patterns for building scalable e-commerce systems.
 
-![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet) ![Angular](https://img.shields.io/badge/Angular-21-DD0031?logo=angular)  ![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker)
+![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet) ![Angular](https://img.shields.io/badge/Angular-21-DD0031?logo=angular)  ![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-![Build](https://github.com/falberthen/ecommerceddd/actions/workflows/ecommerceddd-build.yml/badge.svg)
+![Build](https://github.com/falberthen/ecommerceddd/actions/workflows/ecommerceddd-build.yml/badge.svg) ![GitHub Issues](https://img.shields.io/github/issues/falberthen/ecommerceddd)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ⭐ **If you find this project useful, please consider giving it a star!** It helps others discover the project. ![GitHub Stars](https://img.shields.io/github/stars/falberthen/ecommerceddd?style=social&logo=github)
 
@@ -188,6 +187,13 @@ docker-compose --profile tools run regenerate-clients
 This generates:
 - **Backend clients (C#):** `ServiceClients/Kiota/`
 - **Single Frontend client (TypeScript):** `EcommerceDDD.Spa/src/app/clients/`
+
+---
+
+## 📧 Support & Contributing
+
+- **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/falberthen/EcommerceDDD/issues).
+- **Contributing**: Contributions are welcome! Please read [CONTRIBUTING.md](https://github.com/falberthen/EcommerceDDD/tree/master/docs/CONTRIBUTING.md) before submitting PRs.
 
 ---
 

--- a/src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/EcommerceDDD.Core.Infrastructure.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+		<PackageReference Include="Npgsql.OpenTelemetry" />
 		<PackageReference Include="Polly" />
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />

--- a/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
@@ -55,3 +55,4 @@ global using System.Net.Mime;
 global using System.Reflection;
 global using System.Security.Claims;
 global using System.Text;
+global using Npgsql;

--- a/src/Core/EcommerceDDD.Core.Infrastructure/Kafka/Consumer/KafkaConsumer.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/Kafka/Consumer/KafkaConsumer.cs
@@ -158,20 +158,15 @@ public class KafkaConsumer : IEventConsumer
 					BootstrapServers = _config.ConnectionString,
 					AutoOffsetReset = AutoOffsetReset.Earliest,
 					EnableAutoCommit = false,
-					AllowAutoCreateTopics = true, // Changed to true for better resilience
+					AllowAutoCreateTopics = true,
 					MaxPollIntervalMs = 300000,
-					SessionTimeoutMs = 30000, // Increased timeout
+					SessionTimeoutMs = 30000,
 					EnablePartitionEof = true,
-					// Explicitly configure security to use plaintext
 					SecurityProtocol = SecurityProtocol.Plaintext,
-					// Disable SSL certificate verification
 					SslEndpointIdentificationAlgorithm = SslEndpointIdentificationAlgorithm.None,
 					EnableSslCertificateVerification = false,
-					// Add reconnect settings
 					SocketTimeoutMs = 60000,
 					SocketKeepaliveEnable = true,
-					// Better error handling
-					Debug = "broker,topic,msg"
 				};
 
 				_consumer = new ConsumerBuilder<string, string>(consumerConfig)
@@ -267,7 +262,11 @@ public class KafkaConsumer : IEventConsumer
 				links: links);
 			activity?.SetTag("messaging.system", "kafka");
 			activity?.SetTag("messaging.destination", result.Topic);
+			activity?.SetTag("messaging.operation", "receive");
+			activity?.SetTag("messaging.kafka.consumer_group", _config.Group);
 			activity?.SetTag("messaging.kafka.partition", result.Partition.Value);
+			activity?.SetTag("messaging.kafka.message_offset", result.Offset.Value);
+			activity?.SetTag("messaging.message_id", result.Message.Key);
 
 			// Deserialize the domain event from the raw outbox payload
 			var messageBytes = Encoding.UTF8.GetBytes(result.Message.Value);

--- a/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ActivitySources.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ActivitySources.cs
@@ -3,4 +3,5 @@
 public static class ActivitySources
 {
 	public const string KafkaConsumer = "EcommerceDDD.Kafka.Consumer";
+	public const string OutboxWrite   = "EcommerceDDD.Outbox.Write";
 }


### PR DESCRIPTION
- AddNpgsql.OpenTelemetry, so Marten/PostgreSQL queries appear as spans in the trace timeline.
- Unify traces/metrics/logs pipeline via WithLogging API, eliminating the duplicate ResourceBuilder and aligning service.version across all pillars.
- Add ActivitySource.OutboxWrite and an outbox.publish producer span in MartenRepository, so the TraceContext stored in IntegrationEvent refers to the producer span rather than the raw HTTP span.
- Complete Kafka consumer span with messaging.operation, consumer_group,  message_offset and message_id per OTel Messaging semantic conventions.
- Set ActivityStatusCode.Error and RecordException in GlobalExceptionHandler, so error spans appear red in Aspire Dashboard; include traceId in the error response body for client-side correlation.