### PR TITLE
refactor(otel): centralize command span tagging via ITraceable interface

### DIFF
--- a/src/Core/EcommerceDDD.Core.Infrastructure/CQRS/CommandBus.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/CQRS/CommandBus.cs
@@ -18,6 +18,10 @@ public class CommandBus(
 
 		using var activity = _activitySource.StartActivity(command.GetType().Name, ActivityKind.Internal);
 
+		if (activity is not null && command is ITraceable traceable)
+			foreach (var tag in traceable.GetSpanTags())
+				activity.SetTag(tag.Key, tag.Value);
+
 		Result result;
 		try
 		{

--- a/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ITraceable.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/OpenTelemetry/ITraceable.cs
@@ -1,0 +1,6 @@
+namespace EcommerceDDD.Core.Infrastructure.OpenTelemetry;
+
+public interface ITraceable
+{
+    IEnumerable<KeyValuePair<string, string>> GetSpanTags();
+}

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrder.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrder.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Orders.CancelingOrder;
 
-public record class CancelOrder : ICommand
+public record class CancelOrder : ICommand, ITraceable
 {
 	public OrderId OrderId { get; private set; }
 	public OrderCancellationReason CancellationReason { get; private set; }
@@ -14,6 +14,9 @@ public record class CancelOrder : ICommand
 
 		return new CancelOrder(orderId, CancellationReason);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private CancelOrder(
 		OrderId orderId,

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrderHandler.cs
@@ -12,7 +12,6 @@ public class CancelOrderHandler(
 
 	public async Task<Result> HandleAsync(CancelOrder command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		var order = await _orderWriteRepository
 			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDelivery.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDelivery.cs
@@ -1,6 +1,6 @@
 namespace EcommerceDDD.OrderProcessing.Application.Orders.ConfirmingDelivery;
 
-public record class ConfirmDelivery : ICommand
+public record class ConfirmDelivery : ICommand, ITraceable
 {
 	public OrderId OrderId { get; private set; }
 
@@ -11,6 +11,9 @@ public record class ConfirmDelivery : ICommand
 
 		return new ConfirmDelivery(orderId);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private ConfirmDelivery(OrderId orderId)
 	{

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDeliveryHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDeliveryHandler.cs
@@ -12,7 +12,6 @@ public class ConfirmDeliveryHandler(
 
 	public async Task<Result> HandleAsync(ConfirmDelivery command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		var order = await _orderWriteRepository
 			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrder.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrder.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Orders.ProcessingOrder;
 
-public record class ProcessOrder : ICommand
+public record class ProcessOrder : ICommand, ITraceable
 {
 	public CustomerId CustomerId { get; private set; }
 	public OrderId OrderId { get; private set; }
@@ -20,6 +20,9 @@ public record class ProcessOrder : ICommand
 
 		return new ProcessOrder(customerId, orderId, quoteId);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private ProcessOrder(
 		CustomerId customerId,

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrderHandler.cs
@@ -15,8 +15,6 @@ public class ProcessOrderHandler(
 
 	public async Task<Result> HandleAsync(ProcessOrder command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
-
 		var order = await _orderWriteRepository
 			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPayment.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPayment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Payments.RecordingPayment;
 
-public record class RecordPayment : ICommand
+public record class RecordPayment : ICommand, ITraceable
 {
 	public OrderId OrderId { get; private set; }
 	public PaymentId PaymentId { get; private set; }
@@ -20,6 +20,9 @@ public record class RecordPayment : ICommand
 
 		return new RecordPayment(orderId, paymentId, totalPaid);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private RecordPayment(
 		OrderId orderId,

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPaymentHandler.cs
@@ -12,7 +12,6 @@ public class RecordPaymentHandler(
 
 	public async Task<Result> HandleAsync(RecordPayment command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPayment.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPayment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Payments.RequestingPayment;
 
-public record class RequestPayment: ICommand
+public record class RequestPayment : ICommand, ITraceable
 {
     public CustomerId CustomerId { get; set; }
     public OrderId OrderId { get; set; }
@@ -24,6 +24,9 @@ public record class RequestPayment: ICommand
 
         return new RequestPayment(customerId, orderId, totalPrice, currency);
     }
+
+    public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+        [new("order.id", OrderId.Value.ToString())];
 
     private RequestPayment(
         CustomerId customerId, 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPaymentHandler.cs
@@ -15,7 +15,6 @@ public class RequestPaymentHandler(
 
 	public async Task<Result> HandleAsync(RequestPayment command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipment.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Shipments.RecordingShipment;
 
-public record class RecordShipment : ICommand
+public record class RecordShipment : ICommand, ITraceable
 {
 	public OrderId OrderId { get; private set; }
 	public ShipmentId ShipmentId { get; private set; }
@@ -16,6 +16,9 @@ public record class RecordShipment : ICommand
 
 		return new RecordShipment(orderId, shipmentId);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private RecordShipment(
 		OrderId orderId,

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipmentHandler.cs
@@ -12,7 +12,6 @@ public class RecordShipmentHandler(
 
 	public async Task<Result> HandleAsync(RecordShipment command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipment.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.OrderProcessing.Application.Shipments.RequestingShipment;
 
-public record class RequestShipment : ICommand
+public record class RequestShipment : ICommand, ITraceable
 {
     public OrderId OrderId { get; private set; }
 
@@ -11,6 +11,9 @@ public record class RequestShipment : ICommand
 
         return new RequestShipment(orderId);
     }
+
+    public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+        [new("order.id", OrderId.Value.ToString())];
 
     private RequestShipment(OrderId orderId) => OrderId = orderId;
 }

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipmentHandler.cs
@@ -12,7 +12,6 @@ public class RequestShipmentHandler(
 
 	public async Task<Result> HandleAsync(RequestShipment command, CancellationToken cancellationToken)
 	{
-		Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
 		var order = await _orderWriteRepository
 			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 

--- a/src/Services/EcommerceDDD.OrderProcessing/GlobalUsings.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using EcommerceDDD.Core.Infrastructure.Extensions;
 global using EcommerceDDD.Core.Infrastructure.Identity;
 global using EcommerceDDD.Core.Infrastructure.Kafka;
 global using EcommerceDDD.Core.Infrastructure.Marten;
+global using EcommerceDDD.Core.Infrastructure.OpenTelemetry;
 global using EcommerceDDD.Core.Infrastructure.WebApi;
 global using EcommerceDDD.Core.Persistence;
 global using EcommerceDDD.Core.Validation;

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/ProcessingPayment/ProcessPayment.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/ProcessingPayment/ProcessPayment.cs
@@ -4,8 +4,7 @@ public record class ProcessPayment : ICommand
 {
 	public PaymentId PaymentId { get; private set; }
 
-	public static ProcessPayment Create(
-		PaymentId paymentId)
+	public static ProcessPayment Create(PaymentId paymentId)
 	{
 		if (paymentId is null)
 			throw new ArgumentNullException(nameof(paymentId));

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPayment.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPayment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.PaymentProcessing.Application.RequestingPayment;
 
-public record class RequestPayment : ICommand
+public record class RequestPayment : ICommand, ITraceable
 {
 	public CustomerId CustomerId { get; private set; }
 	public OrderId OrderId { get; private set; }
@@ -28,6 +28,9 @@ public record class RequestPayment : ICommand
 
 		return new RequestPayment(customerId, orderId, totalPrice, currency, productItems);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private RequestPayment(
 		CustomerId customerId,

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPaymentHandler.cs
@@ -10,7 +10,6 @@ public class RequestPaymentHandler(
 
 	public async Task<Result> HandleAsync(RequestPayment command, CancellationToken cancellationToken)
     {
-        Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
         var paymentData = new PaymentData(
             command.CustomerId,
             command.OrderId,

--- a/src/Services/EcommerceDDD.PaymentProcessing/GlobalUsings.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using EcommerceDDD.Core.Exceptions;
 global using EcommerceDDD.Core.Infrastructure.Extensions;
 global using EcommerceDDD.Core.Infrastructure.Identity;
 global using EcommerceDDD.Core.Infrastructure.Marten;
+global using EcommerceDDD.Core.Infrastructure.OpenTelemetry;
 global using EcommerceDDD.Core.Infrastructure.Outbox;
 global using EcommerceDDD.Core.Infrastructure.WebApi;
 global using EcommerceDDD.Core.Persistence;

--- a/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipment.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipment.cs
@@ -1,6 +1,6 @@
 ﻿namespace EcommerceDDD.ShipmentProcessing.Application.RequestingShipment;
 
-public record class RequestShipment : ICommand
+public record class RequestShipment : ICommand, ITraceable
 {
 	public OrderId OrderId { get; private set; }
 	public IReadOnlyList<ProductItem> ProductItems { get; private set; }
@@ -16,6 +16,9 @@ public record class RequestShipment : ICommand
 
 		return new RequestShipment(orderId, productItems);
 	}
+
+	public IEnumerable<KeyValuePair<string, string>> GetSpanTags() =>
+		[new("order.id", OrderId.Value.ToString())];
 
 	private RequestShipment(
 		OrderId orderId,

--- a/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipmentHandler.cs
@@ -12,7 +12,6 @@ public class RequestShipmentHandler(
 
 	public async Task<Result> HandleAsync(RequestShipment command, CancellationToken cancellationToken)
     {
-        Activity.Current?.SetTag("order.id", command.OrderId.Value.ToString());
         var shipmentData = new ShipmentData(command.OrderId, command.ProductItems);
         var shipment = Shipment.Create(shipmentData);
 

--- a/src/Services/EcommerceDDD.ShipmentProcessing/GlobalUsings.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using EcommerceDDD.Core.Exceptions;
 global using EcommerceDDD.Core.Infrastructure.Extensions;
 global using EcommerceDDD.Core.Infrastructure.Identity;
 global using EcommerceDDD.Core.Infrastructure.Marten;
+global using EcommerceDDD.Core.Infrastructure.OpenTelemetry;
 global using EcommerceDDD.Core.Infrastructure.Outbox;
 global using EcommerceDDD.Core.Infrastructure.WebApi;
 global using EcommerceDDD.Core.Persistence;


### PR DESCRIPTION
## Added
Introduces ITraceable, a dedicated interface in Core.Infrastructure.OpenTelemetry, to centralize span tagging in the CommandBus instead of scattering Activity.Current?.SetTag(...) calls across command handlers.

- Commands that carry a known OrderId implement ITraceable.GetSpanTags(). The CommandBus applies the tags automatically when dispatching, only when an active span exists. 
- Handlers where the tag value is not known at dispatch time (e.g., PlaceOrderHandler, where the order ID is generated inside the handler) retain the direct SetTag call as a documented exception.
- Keeps ICommand as a pure dispatch contract and isolates the observability concern behind its own interface.

## Removed
Removes Activity.Current?.SetTag("order.id", ...) from command handlers. The tag is now applied centrally by CommandBus for any command implementing ITraceable, eliminating the risk of new handlers silently missing the annotation.
