### PR TITLE
refactor: name event store repository methods after their effects 

### DIFF
--- a/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using EcommerceDDD.Core.Testing;
 global using EcommerceDDD.Core.Validation;
 global using FluentResults;
 global using JasperFx;
+global using JasperFx.Events;
 global using Marten;
 global using Marten.Newtonsoft;
 global using Microsoft.AspNetCore.Authentication;

--- a/src/Core/EcommerceDDD.Core.Infrastructure/Marten/MartenRepository.cs
+++ b/src/Core/EcommerceDDD.Core.Infrastructure/Marten/MartenRepository.cs
@@ -13,56 +13,66 @@ public class MartenRepository<TA>(
 	private readonly ILogger<MartenRepository<TA>> _logger = logger
 		?? throw new ArgumentNullException(nameof(logger));
 
-	/// <summary>
-	/// Stores uncommited events from an aggregate 
-	/// </summary>
-	/// <param name="aggregate"></param>
-	/// <param name="cancellationToken"></param>
-	/// <returns></returns>
-	public async Task<long> AppendEventsAsync(TA aggregate, CancellationToken cancellationToken = default)
+	private readonly Dictionary<Guid, IEventStream<TA>> _streams = new();
+
+	public async Task<long> AppendEventsAndCommitAsync(TA aggregate, CancellationToken cancellationToken = default,
+		params INotification[] integrationEvents)
     {
         var events = aggregate.GetUncommittedEvents().ToArray();
-        var nextVersion = aggregate.Version + events.Length;
-
         aggregate.ClearUncommittedEvents();
-		_documentSession.Events.Append(aggregate.Id.Value, nextVersion, events);
+
+        long version;
+        if (_streams.TryGetValue(aggregate.Id.Value, out var stream))
+        {
+            // FetchForWriting handed us this stream: append through it so Marten
+            // keeps the optimistic concurrency check it staged on the session.
+            stream.AppendMany(events);
+
+            // Calculating version.
+            version = stream.CurrentVersion.GetValueOrDefault();
+        }
+        else
+        {
+            _documentSession.Events.StartStream<TA>(aggregate.Id.Value, events);
+            version = events.Length;
+        }
+
+        await StageIntegrationEventsAsync(integrationEvents);
 
         await _documentSession.SaveChangesAsync(cancellationToken);
-        return nextVersion;
+        return version;
+    }
+
+    public async Task<TA?> FetchForWritingAsync(Guid id, int? version = null, CancellationToken cancellationToken = default)
+    {
+        var stream = version.HasValue
+            ? await _documentSession.Events.FetchForWriting<TA>(id, version.Value, cancellationToken)
+            : await _documentSession.Events.FetchForWriting<TA>(id, cancellationToken);
+
+        if (stream?.Aggregate is null) return null;
+        _streams[id] = stream;
+        return stream.Aggregate;
     }
 
     /// <summary>
-    /// Fetch domain events from the stream
+    /// Writes the outgoing messages into the same session that holds the aggregate's events,
+    /// so the caller's SaveChangesAsync commits both or neither. Wolverine's durability agent
+    /// relays them to Kafka after the commit and carries the trace context across the hop on its own. 
     /// </summary>
-    /// <param name="id"></param>
-    /// <param name="version"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
-    public async Task<TA?> FetchStreamAsync(Guid id, int? version = null, CancellationToken cancellationToken = default)
+    private async Task StageIntegrationEventsAsync(INotification[] integrationEvents)
     {
-        var aggregate = await _documentSession.Events.AggregateStreamAsync<TA>(
-			id, version ?? 0, 
-			token: cancellationToken
-		);
-		return aggregate;
-    }
+        if (integrationEvents.Length == 0)
+            return;
 
-    /// <summary>
-    /// Stages an integration event in Wolverine's durable outbox.
-    /// Wolverine's durability agent relays it to Kafka afterwards
-    /// and carries the trace context across the hop on its own.
-    /// </summary>
-    /// <param name="event"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public async Task AppendToOutboxAsync(INotification @event)
-    {
-        if (@event is null)
-            throw new ArgumentNullException(nameof(@event));
+        if (Array.Exists(integrationEvents, e => e is null))
+            throw new ArgumentException("Integration events cannot be null.", nameof(integrationEvents));
 
         _outbox.Enroll(_documentSession);
 
-        _logger.LogInformation("Adding integration event {EventName} to outbox...", @event.GetType().Name);
-        await _outbox.PublishAsync(@event);
+        foreach (var @event in integrationEvents)
+        {
+            _logger.LogInformation("Adding integration event {EventName} to outbox...", @event.GetType().Name);
+            await _outbox.PublishAsync(@event);
+        }
     }
 }

--- a/src/Core/EcommerceDDD.Core.Tests/CQRS/CommandHandlerTests.cs
+++ b/src/Core/EcommerceDDD.Core.Tests/CQRS/CommandHandlerTests.cs
@@ -13,7 +13,7 @@ public class CommandHandlerTests
 		await commandHandler.HandleAsync(command, CancellationToken.None);
 
 		// Then
-		await _repository.Received(1).AppendEventsAsync(
+		await _repository.Received(1).AppendEventsAndCommitAsync(
 			Arg.Is<DummyAggregateRoot>(aggregate => aggregate.Id.Value == command.Id.Value),
 			Arg.Any<CancellationToken>());
 	}

--- a/src/Core/EcommerceDDD.Core/Persistence/IEventStoreRepository.cs
+++ b/src/Core/EcommerceDDD.Core/Persistence/IEventStoreRepository.cs
@@ -3,7 +3,14 @@
 public interface IEventStoreRepository<TA>
 	where TA : class, IAggregateRoot<StronglyTypedId<Guid>>
 {
-	Task<long> AppendEventsAsync(TA aggregate, CancellationToken cancellationToken = default);
-	Task<TA?> FetchStreamAsync(Guid id, int? version = null, CancellationToken cancellationToken = default);
-	Task AppendToOutboxAsync(INotification @event);
+	/// <summary>
+	/// Appends the aggregate's uncommitted events and commits them.
+	/// Integration events, when given, are staged in Wolverine's durable outbox on the same
+	/// session, so the events and the outgoing messages share one transaction: either both
+	/// land or neither does. Nothing leaves the process until this commit succeeds.
+	/// </summary>
+	Task<long> AppendEventsAndCommitAsync(TA aggregate, CancellationToken cancellationToken = default,
+		params INotification[] integrationEvents);
+
+	Task<TA?> FetchForWritingAsync(Guid id, int? version = null, CancellationToken cancellationToken = default);
 }

--- a/src/Core/EcommerceDDD.Core/Testing/DummyCommandHandler.cs
+++ b/src/Core/EcommerceDDD.Core/Testing/DummyCommandHandler.cs
@@ -8,7 +8,7 @@ public class DummyCommandHandler(IEventStoreRepository<DummyAggregateRoot> repos
 	public async Task<Result> HandleAsync(DummyCommand command, CancellationToken cancellationToken)
 	{
 		var aggregate = new DummyAggregateRoot(command.Id);
-		await _eventStoreRepository.AppendEventsAsync(aggregate);
+		await _eventStoreRepository.AppendEventsAndCommitAsync(aggregate);
 		return Result.Ok();
 	}
 }

--- a/src/Core/EcommerceDDD.Core/Testing/DummyEventStoreRepository.cs
+++ b/src/Core/EcommerceDDD.Core/Testing/DummyEventStoreRepository.cs
@@ -4,8 +4,10 @@ public class DummyEventStoreRepository<TA> : IEventStoreRepository<TA>
     where TA : class, IAggregateRoot<StronglyTypedId<Guid>>
 {
     public List<StreamAction> AggregateStream = new();
+    public List<INotification> PublishedIntegrationEvents = new();
 
-    public async Task<long> AppendEventsAsync(TA aggregate, CancellationToken cancellationToken = default)
+    public async Task<long> AppendEventsAndCommitAsync(TA aggregate, CancellationToken cancellationToken = default,
+        params INotification[] integrationEvents)
     {
         var nextVersion = aggregate.Version + 1;
         AggregateStream.Add(new StreamAction(
@@ -14,12 +16,12 @@ public class DummyEventStoreRepository<TA> : IEventStoreRepository<TA>
             aggregate.GetUncommittedEvents())
         );
 
+        PublishedIntegrationEvents.AddRange(integrationEvents);
+
         return await Task.FromResult(nextVersion);
     }
 
-    public Task AppendToOutboxAsync(INotification @event) => Task.CompletedTask;
-
-    public Task<TA> FetchStreamAsync(Guid id, int? version = null, CancellationToken cancellationToken = default) 
+    public Task<TA> FetchForWritingAsync(Guid id, int? version = null, CancellationToken cancellationToken = default) 
 		=> Task.FromResult(AggregateStream.FirstOrDefault(c=>c.Stream == id)?.Aggregate!);
 
     public record class StreamAction(
@@ -29,4 +31,3 @@ public class DummyEventStoreRepository<TA> : IEventStoreRepository<TA>
 		IEnumerable<object> Events
 	);
 }
-

--- a/src/Core/EcommerceDDD.Core/Testing/DummyQueryHandler.cs
+++ b/src/Core/EcommerceDDD.Core/Testing/DummyQueryHandler.cs
@@ -9,7 +9,7 @@ public class DummyQueryHandler(IEventStoreRepository<DummyAggregateRoot> reposit
 	{
 		var aggregate = new DummyAggregateRoot(query.Id);
 		aggregate.DoSomething();
-		await _eventStoreRepository.AppendEventsAsync(aggregate);
+		await _eventStoreRepository.AppendEventsAndCommitAsync(aggregate);
 
 		return Result.Ok(aggregate);
 	}

--- a/src/Services/EcommerceDDD.CustomerManagement.Tests/Application/UpdateCustomerInformationHandlerTests.cs
+++ b/src/Services/EcommerceDDD.CustomerManagement.Tests/Application/UpdateCustomerInformationHandlerTests.cs
@@ -1,6 +1,4 @@
-﻿using EcommerceDDD.Core.Infrastructure.Marten;
-using System.Linq.Expressions;
-namespace EcommerceDDD.CustomerManagement.Tests.Application;
+﻿namespace EcommerceDDD.CustomerManagement.Tests.Application;
 
 public class UpdateCustomerInformationHandlerTests
 {
@@ -13,30 +11,11 @@ public class UpdateCustomerInformationHandlerTests
 		string streetAddress = "Rue XYZ";
 		decimal creditLimit = 1000;
 
-		// mock for write-repository
 		var customerWriteRepository = new DummyEventStoreRepository<Customer>();
 		var customerData = new CustomerData(email, name, streetAddress, creditLimit);
 		var customer = Customer.Create(customerData);
-		await customerWriteRepository.AppendEventsAsync(customer);
+		await customerWriteRepository.AppendEventsAndCommitAsync(customer);
 
-		var customerDetails = new CustomerDetails
-		{
-			Id = customer.Id.Value
-		};
-
-		var customerDetailsList = new List<CustomerDetails> { customerDetails }.AsQueryable();
-
-		// mock for query session
-		var martenQueryable = Substitute.For<IMartenQueryable<CustomerDetails>>();
-		martenQueryable.Provider.Returns(customerDetailsList.Provider);
-		martenQueryable.Expression.Returns(customerDetailsList.Expression);
-		martenQueryable.ElementType.Returns(customerDetailsList.ElementType);
-		martenQueryable.GetEnumerator().Returns(customerDetailsList.GetEnumerator());
-		_querySession.QueryFirstOrDefaultAsync<CustomerDetails>(
-			Arg.Any<Expression<Func<CustomerDetails, bool>>>(), Arg.Any<CancellationToken>())
-			.Returns(customerDetails);
-
-		// mock for user info requester
 		_userInfoRequester.GetCurrentUser()
 			.Returns(new UserInfo()
 			{
@@ -48,18 +27,17 @@ public class UpdateCustomerInformationHandlerTests
 			.Create("New Name", "New Address", creditLimit);
 
 		var commandHandler = new UpdateCustomerInformationHandler(
-			_userInfoRequester, _querySession, customerWriteRepository);
+			_userInfoRequester, customerWriteRepository);
 
 		// Act
 		await commandHandler.HandleAsync(updateCommand, CancellationToken.None);
 		var updatedCustomer = await customerWriteRepository
-			.FetchStreamAsync(customer.Id.Value);
+			.FetchForWritingAsync(customer.Id.Value);
 
 		// Assert
 		Assert.Equal("New Name", updatedCustomer.Name);
-		Assert.Equal(updatedCustomer.ShippingAddress, Address.FromStreetAddress("New Address"));		
+		Assert.Equal(updatedCustomer.ShippingAddress, Address.FromStreetAddress("New Address"));
 	}
 
 	private IUserInfoRequester _userInfoRequester = Substitute.For<IUserInfoRequester>();
-	private IQuerySessionWrapper _querySession = Substitute.For<IQuerySessionWrapper>();
 }

--- a/src/Services/EcommerceDDD.CustomerManagement/Application/RegisteringCustomer/RegisterCustomerHandler.cs
+++ b/src/Services/EcommerceDDD.CustomerManagement/Application/RegisteringCustomer/RegisterCustomerHandler.cs
@@ -32,7 +32,7 @@ public class RegisterCustomerHandler(
 			return registerResult;
 
 		await _customerWriteRepository
-			.AppendEventsAsync(customer, cancellationToken);
+			.AppendEventsAndCommitAsync(customer, cancellationToken);
 
 		return Result.Ok();
 	}

--- a/src/Services/EcommerceDDD.CustomerManagement/Application/UpdatingCustomerInformation/UpdateCustomerInformationHandler.cs
+++ b/src/Services/EcommerceDDD.CustomerManagement/Application/UpdatingCustomerInformation/UpdateCustomerInformationHandler.cs
@@ -2,7 +2,6 @@
 
 public class UpdateCustomerInformationHandler(
 	IUserInfoRequester userInfoRequester,
-	IQuerySessionWrapper querySession,
 	IEventStoreRepository<Customer> customerWriteRepository
 )
 {
@@ -10,26 +9,18 @@ public class UpdateCustomerInformationHandler(
 		?? throw new ArgumentNullException(nameof(customerWriteRepository));
 	private readonly IUserInfoRequester _userInfoRequester = userInfoRequester
 		?? throw new ArgumentNullException(nameof(userInfoRequester));
-	private readonly IQuerySessionWrapper _querySession = querySession
-		?? throw new ArgumentNullException(nameof(querySession));
 
 	public async Task<Result> HandleAsync(UpdateCustomerInformation command, CancellationToken cancellationToken)
     {
 		UserInfo? response = _userInfoRequester.GetCurrentUser();
 
-		var customerDetails = await _querySession.QueryFirstOrDefaultAsync<CustomerDetails>(
-			c => c.Id == response!.CustomerId, cancellationToken);
-
-		if (customerDetails is null)
-			return Result.Fail("Customer not found.");
-
 		var customer = await _customerWriteRepository
-			.FetchStreamAsync(customerDetails.Id, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(response!.CustomerId, cancellationToken: cancellationToken);
 
 		if (customer is null)
-			return Result.Fail($"Customer {customerDetails.Id} not found.");
+			return Result.Fail($"Customer {response!.CustomerId} not found.");
 
-        var customerData = new CustomerData(
+		var customerData = new CustomerData(
             customer.Email,
             command.Name,
             command.ShippingAddress,
@@ -38,7 +29,7 @@ public class UpdateCustomerInformationHandler(
         customer.UpdateInformation(customerData);
 
         await _customerWriteRepository
-			.AppendEventsAsync(customer, cancellationToken);
+			.AppendEventsAndCommitAsync(customer, cancellationToken);
 
 		return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/DecreaseQuantityInStockHandlerTests.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/DecreaseQuantityInStockHandlerTests.cs
@@ -21,7 +21,7 @@ public class DecreaseQuantityInStockHandlerTests
 			.Returns(existingEntry);
 
 		var inventoryStockUnit = InventoryStockUnit.EnterStockUnit(ProductId.Of(productId), 10);
-		_inventoryStockUnitRepository.FetchStreamAsync(existingEntry.Id)
+		_inventoryStockUnitRepository.FetchForWritingAsync(existingEntry.Id)
 			.Returns(inventoryStockUnit);
 
 		var handler = new DecreaseStockQuantityHandler(querySessionMock, _inventoryStockUnitRepository);

--- a/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/EnterProductInStockHandlerTests.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/EnterProductInStockHandlerTests.cs
@@ -29,7 +29,7 @@ public class EnterProductInStockHandlerTests
 
 		// Then
 		await _inventoryStockUnitRepository.Received(productIdsQuantities.Count)
-			.AppendEventsAsync(Arg.Is<InventoryStockUnit>(unit =>
+			.AppendEventsAndCommitAsync(Arg.Is<InventoryStockUnit>(unit =>
 				productIdsQuantities.Any(tuple => tuple.Item1 == unit.ProductId)),
 				Arg.Any<CancellationToken>());
 	}

--- a/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/IncreaseQuantityInStockHandlerTests.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement.Tests/Application/IncreaseQuantityInStockHandlerTests.cs
@@ -25,7 +25,7 @@ public class IncreaseQuantityInStockHandlerTests
 			Arg.Any<Expression<Func<InventoryStockUnitDetails, bool>>>(), Arg.Any<CancellationToken>())
 			.Returns(inventoryStockUnitDetails);
 
-		_inventoryStockUnitRepository.FetchStreamAsync(inventoryStockUnit.Id.Value)
+		_inventoryStockUnitRepository.FetchForWritingAsync(inventoryStockUnit.Id.Value)
 			.Returns(inventoryStockUnit);
 
 		var increaseQuantityInStockHandler = new IncreaseQuantityInStockHandler(

--- a/src/Services/EcommerceDDD.InventoryManagement/Application/DecreasingQuantityInStock/DecreaseStockQuantityHandler.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement/Application/DecreasingQuantityInStock/DecreaseStockQuantityHandler.cs
@@ -18,7 +18,7 @@ public class DecreaseStockQuantityHandler(
 
 		Guid inventoryStockUnitId = query.Id;
 		var inventoryStockUnit = await _inventoryStockUnitWriteRepository
-			.FetchStreamAsync(inventoryStockUnitId, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(inventoryStockUnitId, cancellationToken: cancellationToken);
 
 		if (inventoryStockUnit is null)
 			return Result.Fail($"The inventory stock unit {inventoryStockUnitId} was not found.");
@@ -26,7 +26,7 @@ public class DecreaseStockQuantityHandler(
 		inventoryStockUnit.DecreaseStockQuantity(command.QuantityDecreased);
 
 		await _inventoryStockUnitWriteRepository
-			.AppendEventsAsync(inventoryStockUnit);
+			.AppendEventsAndCommitAsync(inventoryStockUnit);
 
 		return Result.Ok();
 	}

--- a/src/Services/EcommerceDDD.InventoryManagement/Application/EnteringProductInStock/EnterProductInStockHandler.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement/Application/EnteringProductInStock/EnterProductInStockHandler.cs
@@ -26,7 +26,7 @@ public class EnterProductInStockHandler(
 					productQuantity.Item1, productQuantity.Item2);
 
 				await _inventoryStockUnitWriteRepository
-					.AppendEventsAsync(inventoryStockUnit);
+					.AppendEventsAndCommitAsync(inventoryStockUnit);
 			}
 		}
 

--- a/src/Services/EcommerceDDD.InventoryManagement/Application/IncreaseQuantityInStock/IncreaseQuantityInStockHandler.cs
+++ b/src/Services/EcommerceDDD.InventoryManagement/Application/IncreaseQuantityInStock/IncreaseQuantityInStockHandler.cs
@@ -20,7 +20,7 @@ public class IncreaseQuantityInStockHandler(
 
         Guid inventoryStockUnitId = existingEntry.Id;
 		var inventoryStockUnit = await _inventoryStockUnitWriteRepository
-			.FetchStreamAsync(inventoryStockUnitId, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(inventoryStockUnitId, cancellationToken: cancellationToken);
 
 		if (inventoryStockUnit is null)
             return Result.Fail($"The inventory stock unit {inventoryStockUnitId} was not found.");
@@ -28,7 +28,7 @@ public class IncreaseQuantityInStockHandler(
         inventoryStockUnit.IncreaseStockQuantity(command.QuantityIncreased);
 
         await _inventoryStockUnitWriteRepository
-			.AppendEventsAsync(inventoryStockUnit, cancellationToken: cancellationToken);
+			.AppendEventsAndCommitAsync(inventoryStockUnit, cancellationToken: cancellationToken);
 
 		return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/CancelOrderHandlerTests.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/CancelOrderHandlerTests.cs
@@ -14,7 +14,7 @@ public class CancelOrderHandlerTests
 
 		var orderWriteRepository = new DummyEventStoreRepository<Order>();
 		await orderWriteRepository
-			.AppendEventsAsync(order);
+			.AppendEventsAndCommitAsync(order);
 
 		var orderNotificationService = Substitute.For<IOrderNotificationService>();
 

--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/ConfirmDeliveryHandlerTests.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/ConfirmDeliveryHandlerTests.cs
@@ -36,7 +36,7 @@ public class ConfirmDeliveryHandlerTests
 
 		var orderWriteRepository = new DummyEventStoreRepository<Order>();
 		await orderWriteRepository
-			.AppendEventsAsync(order);
+			.AppendEventsAndCommitAsync(order);
 
 		var orderNotificationService = Substitute.For<IOrderNotificationService>();
 

--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/ProcessOrderHandlerTests.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/ProcessOrderHandlerTests.cs
@@ -50,7 +50,7 @@ public class ProcessOrderHandlerTests
 			.Returns(viewModelResponse);
 
 		await orderWriteRepository
-			.AppendEventsAsync(order);
+			.AppendEventsAndCommitAsync(order);
 
 		var processOrder = ProcessOrder.Create(customerId, order.Id, quoteId);
 		var processOrderHandler = new ProcessOrderHandler(quoteService, orderWriteRepository, _messageBus);

--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/RecordPaymentToOrderHandlerTests.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/RecordPaymentToOrderHandlerTests.cs
@@ -30,7 +30,7 @@ public class RecordPaymentToOrderHandlerTests
 
 		var orderWriteRepository = new DummyEventStoreRepository<Order>();
 		await orderWriteRepository
-			.AppendEventsAsync(order, CancellationToken.None);
+			.AppendEventsAndCommitAsync(order, CancellationToken.None);
 
 		var orderNotificationService = Substitute.For<IOrderNotificationService>();
 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/CancelingOrder/CancelOrderHandler.cs
@@ -16,7 +16,7 @@ public class CancelOrderHandler(
 	public async Task<Result> HandleAsync(CancelOrder command, CancellationToken cancellationToken)
 	{
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");
@@ -31,7 +31,7 @@ public class CancelOrderHandler(
 			.FirstOrDefault();
 
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken: cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken: cancellationToken);
 
 		// Lets the saga cancel the payment when the order had already been paid
 		await _messageBus.PublishAsync(orderCanceledEvent!);

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDeliveryHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ConfirmingDelivery/ConfirmDeliveryHandler.cs
@@ -16,7 +16,7 @@ public class ConfirmDeliveryHandler(
 	public async Task<Result> HandleAsync(ConfirmDelivery command, CancellationToken cancellationToken)
 	{
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");
@@ -32,7 +32,7 @@ public class ConfirmDeliveryHandler(
 		order.Deliver(order.ShipmentId);
 
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken: cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken: cancellationToken);
 
 		try
 		{

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/PlacingOrder/PlaceOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/PlacingOrder/PlaceOrderHandler.cs
@@ -1,4 +1,4 @@
-namespace EcommerceDDD.OrderProcessing.Application.Orders.PlacingOrder;
+﻿namespace EcommerceDDD.OrderProcessing.Application.Orders.PlacingOrder;
 
 public class PlaceOrderHandler(
 	IOrderNotificationService orderNotificationService,
@@ -58,10 +58,8 @@ public class PlaceOrderHandler(
 
 		var orderPlacedEvent = order.GetUncommittedEvents()
 			.OfType<OrderPlaced>().FirstOrDefault();
-		await _orderWriteRepository.AppendToOutboxAsync(orderPlacedEvent!);
-
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken, orderPlacedEvent!);
 
 		try
 		{

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/ProcessingOrder/ProcessOrderHandler.cs
@@ -16,7 +16,7 @@ public class ProcessOrderHandler(
 	public async Task<Result> HandleAsync(ProcessOrder command, CancellationToken cancellationToken)
 	{
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Order {command.OrderId} not found.");
@@ -77,7 +77,7 @@ public class ProcessOrderHandler(
 		   .FirstOrDefault();
 
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken);
 
 		await _messageBus.PublishAsync(orderProcessedEvent!);
 

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RecordingPayment/RecordPaymentHandler.cs
@@ -18,7 +18,7 @@ public class RecordPaymentHandler(
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");
@@ -43,7 +43,7 @@ public class RecordPaymentHandler(
 			.FirstOrDefault();
 
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken);
 
 		// Tells the saga the order is paid, which is what releases the shipment request
 		await _messageBus.PublishAsync(orderPaidEvent!);

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Payments/RequestingPayment/RequestPaymentHandler.cs
@@ -18,7 +18,7 @@ public class RequestPaymentHandler(
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RecordingShipment/RecordShipmentHandler.cs
@@ -15,7 +15,7 @@ public class RecordShipmentHandler(
 		await Task.Delay(TimeSpan.FromSeconds(5));
 
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");
@@ -25,7 +25,7 @@ public class RecordShipmentHandler(
 
 		order.RecordShipment(command.ShipmentId);
 		await _orderWriteRepository
-			.AppendEventsAsync(order, cancellationToken);
+			.AppendEventsAndCommitAsync(order, cancellationToken);
 
 		try
 		{

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Shipments/RequestingShipment/RequestShipmentHandler.cs
@@ -13,7 +13,7 @@ public class RequestShipmentHandler(
 	public async Task<Result> HandleAsync(RequestShipment command, CancellationToken cancellationToken)
 	{
 		var order = await _orderWriteRepository
-			.FetchStreamAsync(command.OrderId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.OrderId.Value, cancellationToken: cancellationToken);
 
 		if (order is null)
 			return Result.Fail($"Failed to find the order {command.OrderId}.");

--- a/src/Services/EcommerceDDD.PaymentProcessing.Tests/Application/CancelPaymentHandlerTests.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing.Tests/Application/CancelPaymentHandlerTests.cs
@@ -18,7 +18,7 @@ public class CancelPaymentHandlerTests
 		var payment = Payment.Create(new PaymentData(customerId, orderId, totalAmount, productItems));
 
         var paymentWriteRepository = new DummyEventStoreRepository<Payment>();
-        await paymentWriteRepository.AppendEventsAsync(payment);
+        await paymentWriteRepository.AppendEventsAndCommitAsync(payment);
 
         var cancelPayment = CancelPayment.Create(orderId, payment.Id, (int)PaymentCancellationReason.OrderCanceled);
         var cancelPaymentHandler = new CancelPaymentHandler(paymentWriteRepository);

--- a/src/Services/EcommerceDDD.PaymentProcessing.Tests/Application/ProcessPaymentHandlerTests.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing.Tests/Application/ProcessPaymentHandlerTests.cs
@@ -18,7 +18,7 @@ public class ProcessPaymentHandlerTests
 		var payment = Payment.Create(new PaymentData(customerId, orderId, totalAmount, productItems));
 
 		var paymentWriteRepository = new DummyEventStoreRepository<Payment>();
-		await paymentWriteRepository.AppendEventsAsync(payment);
+		await paymentWriteRepository.AppendEventsAndCommitAsync(payment);
 
 		_customerCreditChecker.
 			CheckIfCreditIsEnoughAsync(Arg.Any<CustomerId>(), Arg.Any<Money>(), CancellationToken.None)
@@ -59,7 +59,7 @@ public class ProcessPaymentHandlerTests
 		var payment = Payment.Create(new PaymentData(customerId, orderId, totalAmount, productItems));
 
 		var paymentWriteRepository = new DummyEventStoreRepository<Payment>();
-		await paymentWriteRepository.AppendEventsAsync(payment);
+		await paymentWriteRepository.AppendEventsAndCommitAsync(payment);
 
 		_customerCreditChecker
 			.CheckIfCreditIsEnoughAsync(Arg.Any<CustomerId>(), Arg.Any<Money>(), CancellationToken.None)

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/CancelingPayment/CancelPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/CancelingPayment/CancelPaymentHandler.cs
@@ -7,7 +7,7 @@ public class CancelPaymentHandler(IEventStoreRepository<Payment> paymentWriteRep
 	public async Task<Result> HandleAsync(CancelPayment command, CancellationToken cancellationToken)
     {
         var payment = await _paymentWriteRepository
-			.FetchStreamAsync(command.PaymentId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.PaymentId.Value, cancellationToken: cancellationToken);
 
         if (payment is null)
             return Result.Fail($"Failed to find the payment {command.PaymentId}.");
@@ -15,7 +15,7 @@ public class CancelPaymentHandler(IEventStoreRepository<Payment> paymentWriteRep
         // Canceling payment
         payment.Cancel(command.PaymentCancellationReason);
         await _paymentWriteRepository
-			.AppendEventsAsync(payment, cancellationToken);
+			.AppendEventsAndCommitAsync(payment, cancellationToken);
 
         return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/ProcessingPayment/ProcessPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/ProcessingPayment/ProcessPaymentHandler.cs
@@ -1,4 +1,4 @@
-namespace EcommerceDDD.PaymentProcessing.Application.ProcessingPayment;
+﻿namespace EcommerceDDD.PaymentProcessing.Application.ProcessingPayment;
 
 public class ProcessPaymentHandler(
 	IProductInventoryHandler productInventoryHandler,
@@ -13,81 +13,57 @@ public class ProcessPaymentHandler(
 	public async Task<Result> HandleAsync(ProcessPayment command, CancellationToken cancellationToken)
 	{
 		var payment = await _paymentWriteRepository
-			.FetchStreamAsync(command.PaymentId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.PaymentId.Value, cancellationToken: cancellationToken);
 
 		if (payment is null)
 			return Result.Fail($"Payment {command.PaymentId.Value} was not found.");
+
+		INotification integrationEvent;
+		var result = Result.Ok();
 
 		try
 		{
 			if (!await _creditChecker
 				.CheckIfCreditIsEnoughAsync(payment.CustomerId, payment.TotalAmount, cancellationToken))
 			{
-				await CancelPaymentAsync(payment, PaymentCancellationReason.CustomerReachedCreditLimit, cancellationToken);
-				return Result.Ok();
+				payment.Cancel(PaymentCancellationReason.CustomerReachedCreditLimit);
+				integrationEvent = new CustomerReachedCreditLimit(payment.OrderId.Value);
 			}
-
-			bool allProductsAreAvailable = await _productInventoryHandler
-				.CheckProductsInStockAsync(payment.ProductItems, cancellationToken);
-			if (!allProductsAreAvailable)
+			else if (!await _productInventoryHandler
+				.CheckProductsInStockAsync(payment.ProductItems, cancellationToken))
 			{
-				await CancelPaymentAsync(payment, PaymentCancellationReason.ProductOutOfStock, cancellationToken);
-				return Result.Ok();
+				payment.Cancel(PaymentCancellationReason.ProductOutOfStock);
+				integrationEvent = new ProductWasOutOfStock(payment.OrderId.Value);
 			}
+			else
+			{
+				await _productInventoryHandler
+					.DecreaseQuantityInStockAsync(payment.ProductItems, cancellationToken);
 
-			await _productInventoryHandler
-				.DecreaseQuantityInStockAsync(payment.ProductItems, cancellationToken);
-
-			payment.Complete();
-
-			await _paymentWriteRepository.AppendToOutboxAsync(
-			   new PaymentFinalized(
-				   payment.Id.Value,
-				   payment.OrderId.Value,
-				   payment.TotalAmount.Amount,
-				   payment.TotalAmount.Currency.Code,
-				   payment.CompletedAt!.Value));
-
-			await _paymentWriteRepository
-				.AppendEventsAsync(payment, cancellationToken);
-
-			return Result.Ok();
+				payment.Complete();
+				integrationEvent = new PaymentFinalized(
+					payment.Id.Value,
+					payment.OrderId.Value,
+					payment.TotalAmount.Amount,
+					payment.TotalAmount.Currency.Code,
+					payment.CompletedAt!.Value);
+			}
 		}
 		catch (Exception)
 		{
 			payment.Cancel(PaymentCancellationReason.ProcessmentError);
+			integrationEvent = new PaymentFailed(
+				payment.Id.Value,
+				payment.OrderId.Value,
+				payment.TotalAmount.Amount,
+				payment.TotalAmount.Currency.Code);
 
-			await _paymentWriteRepository.AppendToOutboxAsync(
-				new PaymentFailed(
-					payment.Id.Value,
-					payment.OrderId.Value,
-					payment.TotalAmount.Amount,
-					payment.TotalAmount.Currency.Code));
-
-			await _paymentWriteRepository
-				.AppendEventsAsync(payment, cancellationToken);
-
-			return Result.Fail($"An unexpected error occurred processing payment {command.PaymentId}.");
-		}
-	}
-
-	private async Task CancelPaymentAsync(Payment payment, PaymentCancellationReason reason,
-		CancellationToken cancellationToken)
-	{
-		payment.Cancel(reason);
-
-		if (reason == PaymentCancellationReason.CustomerReachedCreditLimit)
-		{
-			await _paymentWriteRepository.AppendToOutboxAsync(
-				new CustomerReachedCreditLimit(payment.OrderId.Value));
-		}
-		if (reason == PaymentCancellationReason.ProductOutOfStock)
-		{
-			await _paymentWriteRepository.AppendToOutboxAsync(
-				new ProductWasOutOfStock(payment.OrderId.Value));
+			result = Result.Fail($"An unexpected error occurred processing payment {command.PaymentId}.");
 		}
 
 		await _paymentWriteRepository
-			.AppendEventsAsync(payment, cancellationToken);
+			.AppendEventsAndCommitAsync(payment, cancellationToken, integrationEvent);
+
+		return result;
 	}
 }

--- a/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPaymentHandler.cs
+++ b/src/Services/EcommerceDDD.PaymentProcessing/Application/RequestingPayment/RequestPaymentHandler.cs
@@ -19,7 +19,7 @@ public class RequestPaymentHandler(
         var payment = Payment.Create(paymentData);
 
         await _paymentWriteRepository
-			.AppendEventsAsync(payment, cancellationToken);
+			.AppendEventsAndCommitAsync(payment, cancellationToken);
 
         return await _bus.InvokeAsync<Result>(
             ProcessPayment.Create(payment.Id, command.OrderId), cancellationToken);

--- a/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/AddQuoteItemHandlerTests.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/AddQuoteItemHandlerTests.cs
@@ -23,7 +23,7 @@ public class AddQuoteItemHandlerTests
 		var quote = Quote.OpenQuoteForCustomer(_customerId, _currency);
 
 		var quoteWriteRepository = new DummyEventStoreRepository<Quote>();
-		await quoteWriteRepository.AppendEventsAsync(quote);
+		await quoteWriteRepository.AppendEventsAndCommitAsync(quote);
 
 		var addQuoteItem = AddQuoteItem.Create(quote.Id, _productId, _productQuantity);
 		var addQuoteItemHandler = new AddQuoteItemHandler(quoteWriteRepository, _productMapper, _userInfoRequester);
@@ -57,7 +57,7 @@ public class AddQuoteItemHandlerTests
 		var quote = Quote.OpenQuoteForCustomer(_customerId, _currency);
 
 		var quoteWriteRepository = new DummyEventStoreRepository<Quote>();
-		await quoteWriteRepository.AppendEventsAsync(quote);
+		await quoteWriteRepository.AppendEventsAndCommitAsync(quote);
 
 		var addQuoteItem = AddQuoteItem.Create(quote.Id, _productId, _productQuantity);
 		var addQuoteItemHandler = new AddQuoteItemHandler(quoteWriteRepository, _productMapper, _userInfoRequester);

--- a/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/ConfirmQuoteHandlerTests.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/ConfirmQuoteHandlerTests.cs
@@ -16,7 +16,7 @@ public class ConfirmQuoteHandlerTests
 			Money.Of(10, currency.Code), productQuantity));
 
 		var quoteWriteRepository = new DummyEventStoreRepository<Quote>();
-		await quoteWriteRepository.AppendEventsAsync(quote);
+		await quoteWriteRepository.AppendEventsAndCommitAsync(quote);
 
 		var confirmQuote = ConfirmQuote.Create(quote.Id);
 		var confirmQuoteHandler = new ConfirmQuoteHandler(quoteWriteRepository);
@@ -38,7 +38,7 @@ public class ConfirmQuoteHandlerTests
 		var quote = Quote.OpenQuoteForCustomer(customerId, currency);
 		var quoteWriteRepository = new DummyEventStoreRepository<Quote>();
 
-		await quoteWriteRepository.AppendEventsAsync(quote);
+		await quoteWriteRepository.AppendEventsAndCommitAsync(quote);
 		var confirmQuote = ConfirmQuote.Create(quote.Id);
 		var confirmQuoteHandler = new ConfirmQuoteHandler(quoteWriteRepository);
 

--- a/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/RemoveQuoteItemHandlerTests.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement.Tests/Application/RemoveQuoteItemHandlerTests.cs
@@ -17,7 +17,7 @@ public class RemoveQuoteItemHandlerTests
 			Money.Of(10, currency.Code), productQuantity));
 
 		var quoteWriteRepository = new DummyEventStoreRepository<Quote>();
-		await quoteWriteRepository.AppendEventsAsync(quote);
+		await quoteWriteRepository.AppendEventsAndCommitAsync(quote);
 
 		var userInfoRequester = Substitute.For<IUserInfoRequester>();
 		userInfoRequester.GetCurrentUser()

--- a/src/Services/EcommerceDDD.QuoteManagement/Application/AddingQuoteItem/AddQuoteItemHandler.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement/Application/AddingQuoteItem/AddQuoteItemHandler.cs
@@ -14,7 +14,7 @@ public class AddQuoteItemHandler(
 	public async Task<Result> HandleAsync(AddQuoteItem command, CancellationToken cancellationToken)
     {
         var quote = await _quoteWriteRepository
-			.FetchStreamAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
 
         if (quote is null)
             return Result.Fail($"The quote {command.QuoteId.Value} was not found.");
@@ -46,7 +46,7 @@ public class AddQuoteItemHandler(
 		quote.AddItem(quotetemData);
 
 		await _quoteWriteRepository
-			.AppendEventsAsync(quote, cancellationToken);
+			.AppendEventsAndCommitAsync(quote, cancellationToken);
 
         return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.QuoteManagement/Application/CancelingQuote/CancelQuoteHandler.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement/Application/CancelingQuote/CancelQuoteHandler.cs
@@ -12,7 +12,7 @@ public class CancelQuoteHandler(
 	public async Task<Result> HandleAsync(CancelQuote command, CancellationToken cancellationToken)
     {
         var quote = await _quoteWriteRepository
-			.FetchStreamAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
 
         if (quote is null)
             return Result.Fail($"The quote {command.QuoteId.Value} was not found.");
@@ -25,7 +25,7 @@ public class CancelQuoteHandler(
         quote.Cancel();
 
         await _quoteWriteRepository
-			.AppendEventsAsync(quote, cancellationToken);
+			.AppendEventsAndCommitAsync(quote, cancellationToken);
 
         return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.QuoteManagement/Application/ConfirmingQuote/ConfirmQuoteHandler.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement/Application/ConfirmingQuote/ConfirmQuoteHandler.cs
@@ -9,7 +9,7 @@ public class ConfirmQuoteHandler(
 	public async Task<Result> HandleAsync(ConfirmQuote command, CancellationToken cancellationToken)
     {
         var quote = await _quoteWriteRepository
-			.FetchStreamAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
 
         if (quote is null)
             return Result.Fail($"The quote {command.QuoteId} not found.");
@@ -17,7 +17,7 @@ public class ConfirmQuoteHandler(
         quote.Confirm();
 
         await _quoteWriteRepository
-			.AppendEventsAsync(quote, cancellationToken);
+			.AppendEventsAndCommitAsync(quote, cancellationToken);
 
         return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.QuoteManagement/Application/OpeningQuote/OpenQuoteHandler.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement/Application/OpeningQuote/OpenQuoteHandler.cs
@@ -26,7 +26,7 @@ public class OpenQuoteHandler(
         var quote = Quote.OpenQuoteForCustomer(customerId, command.Currency);
 
         await _quoteWriteRepository
-			.AppendEventsAsync(quote, cancellationToken);
+			.AppendEventsAndCommitAsync(quote, cancellationToken);
 
         return Result.Ok();
     }

--- a/src/Services/EcommerceDDD.QuoteManagement/Application/RemovingQuoteItem/RemoveQuoteItemHandler.cs
+++ b/src/Services/EcommerceDDD.QuoteManagement/Application/RemovingQuoteItem/RemoveQuoteItemHandler.cs
@@ -12,7 +12,7 @@ public class RemoveQuoteItemHandler(
 	public async Task<Result> HandleAsync(RemoveQuoteItem command, CancellationToken cancellationToken)
 	{
 		var quote = await _quoteWriteRepository
-			.FetchStreamAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
+			.FetchForWritingAsync(command.QuoteId.Value, cancellationToken: cancellationToken);
 
 		if (quote is null)
 			return Result.Fail($"The quote {command.QuoteId} not found.");
@@ -25,7 +25,7 @@ public class RemoveQuoteItemHandler(
 		quote.RemoveItem(command.ProductId);
 
 		await _quoteWriteRepository
-			.AppendEventsAsync(quote, cancellationToken);
+			.AppendEventsAndCommitAsync(quote, cancellationToken);
 
 		return Result.Ok();
 	}

--- a/src/Services/EcommerceDDD.ShipmentProcessing.Tests/GlobalUsings.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing.Tests/GlobalUsings.cs
@@ -2,7 +2,6 @@ global using EcommerceDDD.Core.Exceptions;
 global using EcommerceDDD.Core.Testing;
 global using EcommerceDDD.ShipmentProcessing.API.Controllers;
 global using EcommerceDDD.ShipmentProcessing.API.Controllers.Requests;
-global using EcommerceDDD.ShipmentProcessing.Application.ProcessingPayment.IntegrationEvents;
 global using EcommerceDDD.ShipmentProcessing.Application.ProcessingShipment;
 global using EcommerceDDD.ShipmentProcessing.Application.RequestingShipment;
 global using EcommerceDDD.ShipmentProcessing.Domain;

--- a/src/Services/EcommerceDDD.ShipmentProcessing/Application/ProcessingShipment/ProcessShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/Application/ProcessingShipment/ProcessShipmentHandler.cs
@@ -1,6 +1,4 @@
-using EcommerceDDD.ShipmentProcessing.Application.ProcessingShipment;
-
-namespace EcommerceDDD.ShipmentProcessing.Application.ProcessingPayment.IntegrationEvents;
+﻿namespace EcommerceDDD.ShipmentProcessing.Application.ProcessingShipment;
 
 public class ProcessShipmentHandler(
 	IEventStoreRepository<Shipment> shipmentWriteRepository
@@ -11,37 +9,34 @@ public class ProcessShipmentHandler(
 	public async Task<Result> HandleAsync(ProcessShipment command, CancellationToken cancellationToken)
 	{
 		var shipment = await _shipmentWriteRepository
-				.FetchStreamAsync(command.ShipmentId.Value, cancellationToken: cancellationToken);
+				.FetchForWritingAsync(command.ShipmentId.Value, cancellationToken: cancellationToken);
 
 		if (shipment is null)
 			return Result.Fail($"The shipment {command.ShipmentId.Value} was not found.");
 
+		INotification integrationEvent;
+		var result = Result.Ok();
+		
 		try
 		{
 			shipment.Complete();
 
-			await _shipmentWriteRepository.AppendToOutboxAsync(
-				new ShipmentFinalized(
-					shipment.Id.Value,
-					shipment.OrderId.Value,
-					shipment.ShippedAt!.Value));
-
-			await _shipmentWriteRepository
-				.AppendEventsAsync(shipment, cancellationToken);
-
-			return Result.Ok();
+			integrationEvent = new ShipmentFinalized(
+				shipment.Id.Value,
+				shipment.OrderId.Value,
+				shipment.ShippedAt!.Value);
 		}
 		catch (Exception)
 		{
 			shipment.Cancel(ShipmentCancellationReason.ProcessmentError);
+			integrationEvent = new ShipmentFailed(shipment.Id.Value, shipment.OrderId.Value);
 
-			await _shipmentWriteRepository.AppendToOutboxAsync(
-				new ShipmentFailed(shipment.Id.Value, shipment.OrderId.Value));
-
-			await _shipmentWriteRepository
-				.AppendEventsAsync(shipment, cancellationToken);
-
-			return Result.Fail($"An unexpected error occurred processing shipment {command.ShipmentId}.");
+			result = Result.Fail($"An unexpected error occurred processing shipment {command.ShipmentId}.");
 		}
+
+		await _shipmentWriteRepository
+			.AppendEventsAndCommitAsync(shipment, cancellationToken, integrationEvent);
+
+		return result;
 	}
 }

--- a/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipmentHandler.cs
+++ b/src/Services/EcommerceDDD.ShipmentProcessing/Application/RequestingShipment/RequestShipmentHandler.cs
@@ -16,7 +16,7 @@ public class RequestShipmentHandler(
         var shipment = Shipment.Create(shipmentData);
 
         await _shipmentWriteRepository
-			.AppendEventsAsync(shipment, cancellationToken);
+			.AppendEventsAndCommitAsync(shipment, cancellationToken);
 
         return await _bus
 			.InvokeAsync<Result>(ProcessShipment.Create(shipment.Id, command.OrderId), cancellationToken);


### PR DESCRIPTION
Renames the three `IEventStoreRepository<TA>` methods to describe their effect on the caller, folds the outbox publish into the commit, and fixes a double-commit bug in the payment and shipment handlers.

## Why

The old names described the Marten call being wrapped, not what the caller gets:

| Before | After | What was hidden |
|---|---|---|
| `FetchStreamAsync` | `FetchForWritingAsync` | Keeps the `IEventStream` for the next append |
| `AppendEventsAsync` | `AppendEventsAndCommitAsync` | Calls `SaveChangesAsync`; it is the transaction boundary |