### PR TITLE
refactor: keep OrderPlaced in-process instead of round-tripping through Kafka

### DIFF
--- a/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/PlaceOrderHandlerTests.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing.Tests/Application/PlaceOrderHandlerTests.cs
@@ -37,7 +37,7 @@ public class PlaceOrderHandlerTests
 
 		var placeOrder = PlaceOrder.Create(_quoteId);
 		var placeOrderHandler = new PlaceOrderHandler(orderNotificationService, quoteService,
-			orderWriteRepository, GivenCurrentCustomer(customerId.Value));
+			orderWriteRepository, GivenCurrentCustomer(customerId.Value), Substitute.For<IMessageBus>());
 
 		// When
 		await placeOrderHandler.HandleAsync(placeOrder, CancellationToken.None);
@@ -81,7 +81,7 @@ public class PlaceOrderHandlerTests
 
 		var placeOrder = PlaceOrder.Create(_quoteId);
 		var placeOrderHandler = new PlaceOrderHandler(orderNotificationService, quoteService,
-			orderWriteRepository, GivenCurrentCustomer(currentCustomerId));
+			orderWriteRepository, GivenCurrentCustomer(currentCustomerId), Substitute.For<IMessageBus>());
 
 		// When
 		var result = await placeOrderHandler.HandleAsync(placeOrder, CancellationToken.None);
@@ -111,7 +111,7 @@ public class PlaceOrderHandlerTests
 
 		var placeOrder = PlaceOrder.Create(_quoteId);
 		var placeOrderHandler = new PlaceOrderHandler(orderNotificationService, quoteService,
-			orderWriteRepository, GivenCurrentCustomer(customerId));
+			orderWriteRepository, GivenCurrentCustomer(customerId), Substitute.For<IMessageBus>());
 
 		// When
 		var result = await placeOrderHandler.HandleAsync(placeOrder, CancellationToken.None);

--- a/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/PlacingOrder/PlaceOrderHandler.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Application/Orders/PlacingOrder/PlaceOrderHandler.cs
@@ -4,7 +4,8 @@ public class PlaceOrderHandler(
 	IOrderNotificationService orderNotificationService,
 	IQuoteService quoteService,
 	IEventStoreRepository<Order> orderWriteRepository,
-	IUserInfoRequester userInfoRequester
+	IUserInfoRequester userInfoRequester,
+	IMessageBus messageBus
 )
 {
 	private readonly IOrderNotificationService _orderNotificationService = orderNotificationService
@@ -15,6 +16,8 @@ public class PlaceOrderHandler(
 		?? throw new ArgumentNullException(nameof(orderWriteRepository));
 	private readonly IUserInfoRequester _userInfoRequester = userInfoRequester
 		?? throw new ArgumentNullException(nameof(userInfoRequester));
+	private readonly IMessageBus _messageBus = messageBus
+		?? throw new ArgumentNullException(nameof(messageBus));
 
 	public async Task<Result> HandleAsync(PlaceOrder command, CancellationToken cancellationToken)
 	{
@@ -58,8 +61,12 @@ public class PlaceOrderHandler(
 
 		var orderPlacedEvent = order.GetUncommittedEvents()
 			.OfType<OrderPlaced>().FirstOrDefault();
+
 		await _orderWriteRepository
-			.AppendEventsAndCommitAsync(order, cancellationToken, orderPlacedEvent!);
+			.AppendEventsAndCommitAsync(order, cancellationToken);
+
+		// Lets the saga start the order fulfilment
+		await _messageBus.PublishAsync(orderPlacedEvent!);
 
 		try
 		{

--- a/src/Services/EcommerceDDD.OrderProcessing/Domain/Events/OrderPlaced.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Domain/Events/OrderPlaced.cs
@@ -1,6 +1,5 @@
 namespace EcommerceDDD.OrderProcessing.Domain.Events;
 
-[MessageIdentity(nameof(OrderPlaced))]
 public record class OrderPlaced(
     Guid CustomerId,
     Guid OrderId,

--- a/src/Services/EcommerceDDD.OrderProcessing/Program.cs
+++ b/src/Services/EcommerceDDD.OrderProcessing/Program.cs
@@ -16,13 +16,7 @@ services.AddCoreInfrastructure(builder.Configuration, options =>
 	options.UseKafka(builder.Configuration["Kafka:ConnectionString"]!)
 		.AutoProvision();
 
-	// OrderPlaced still crosses the broker: an explicit subscription wins over
-	// Wolverine's local routing, so it is not also handled in-process.
-	options.PublishMessage<OrderPlaced>()
-		.ToKafkaTopic("orders")
-		.UseDurableOutbox();
-
-	options.ListenToKafkaTopic("orders").UseDurableInbox();
+	// payment and shipment integration events cross the broker.
 	options.ListenToKafkaTopic("payments").UseDurableInbox();
 	options.ListenToKafkaTopic("shipments").UseDurableInbox();
 });


### PR DESCRIPTION
## Changes

- **`Program.cs`**: remove `PublishMessage<OrderPlaced>().ToKafkaTopic("orders")`  and `ListenToKafkaTopic("orders")`. The broker now carries only the `payments` and `shipments` integration events.
- **`OrderPlaced`**: remove `[MessageIdentity]`; it is no longer a wire message.
- **`PlaceOrderHandler`**: inject `IMessageBus` and publish `OrderPlaced` right after `AppendEventsAndCommitAsync`.